### PR TITLE
feat: extract compliance content from artisanpack-ui/security 1.x

### DIFF
--- a/config/artisanpack/compliance.php
+++ b/config/artisanpack/compliance.php
@@ -1,0 +1,171 @@
+<?php
+
+return [
+    'compliance' => [
+        'enabled' => env('COMPLIANCE_ENABLED', true),
+
+        // Default regulation to enforce
+        'default_regulation' => env('COMPLIANCE_REGULATION', 'gdpr'),
+
+        // Supported regulations
+        'regulations' => ['gdpr', 'ccpa', 'lgpd', 'pipeda', 'popia', 'pdpa'],
+
+        // Data Protection Impact Assessments
+        'dpia' => [
+            'enabled' => true,
+            'auto_require_high_risk' => true,
+            'review_reminder_days' => 365,
+            'require_dpo_review' => true,
+            'export_formats' => ['pdf', 'docx', 'html'],
+            // Risk calculation method for overall risk score
+            // Options:
+            //   'highest' - Use the highest individual risk score (default)
+            //   'average' - Use the average of all risk scores
+            //   'weighted' - Use weighted average based on severity (critical: 4x, high: 3x, medium: 2x, low: 1x)
+            'risk_calculation_method' => 'highest',
+        ],
+
+        // Privacy by Design
+        'privacy_by_design' => [
+            'enabled' => true,
+            'auto_encrypt_sensitive' => true,
+            'log_data_access' => true,
+            'default_retention_days' => null, // null = indefinite
+            'audit_trail_enabled' => true,
+        ],
+
+        // Data Minimization
+        'minimization' => [
+            'enabled' => true,
+            'enforce_collection_policies' => true,
+            'auto_purge_expired' => env('AUTO_PURGE_EXPIRED_DATA', false),
+            'purge_batch_size' => 1000,
+            'anonymization_algorithm' => 'sha256', // sha256, bcrypt
+        ],
+
+        // Right to Erasure
+        'erasure' => [
+            'enabled' => true,
+            'require_identity_verification' => true,
+            'verification_methods' => ['email', 'sms', 'document'],
+            'grace_period_days' => 7, // Days before permanent deletion
+            'deadline_days' => 30, // Legal deadline to respond
+            'notify_third_parties' => true,
+            'generate_certificate' => true,
+            'handlers' => [
+                // List of erasure handler classes
+            ],
+        ],
+
+        // Data Portability
+        'portability' => [
+            'enabled' => true,
+            'deadline_days' => 30,
+            'default_format' => 'json',
+            'supported_formats' => ['json', 'xml', 'csv'],
+            'download_expiry_hours' => 72,
+            'max_download_attempts' => 5,
+            'allow_direct_transfer' => true,
+            'max_export_size_mb' => 500,
+            'chunk_size' => 1000,
+        ],
+
+        // Consent Management
+        'consent' => [
+            'enabled' => true,
+            'require_explicit' => true,
+            'default_expiry_days' => null, // null = no expiry
+            'reconsent_on_policy_change' => true,
+            'minimum_age' => 16, // GDPR default
+            'cookie_consent' => [
+                'enabled' => true,
+                'banner_position' => 'bottom',
+                'categories' => ['essential', 'functional', 'analytics', 'marketing'],
+            ],
+            'purposes' => [
+                'essential' => [
+                    'name' => 'Essential',
+                    'required' => true,
+                    'description' => 'Required for basic site functionality',
+                ],
+                'functional' => [
+                    'name' => 'Functional',
+                    'required' => false,
+                    'description' => 'Enhanced functionality and personalization',
+                ],
+                'analytics' => [
+                    'name' => 'Analytics',
+                    'required' => false,
+                    'description' => 'Usage analytics and improvement',
+                ],
+                'marketing' => [
+                    'name' => 'Marketing',
+                    'required' => false,
+                    'description' => 'Marketing and advertising',
+                ],
+            ],
+        ],
+
+        // Compliance Dashboard
+        'dashboard' => [
+            'enabled' => true,
+            'refresh_interval' => 300, // seconds
+            'require_permission' => 'compliance.dashboard.view',
+            'score_calculation_cron' => '0 0 * * *', // Daily at midnight
+        ],
+
+        // Automated Compliance Checking
+        'monitoring' => [
+            'enabled' => true,
+            'check_schedule' => '0 */6 * * *', // Every 6 hours
+            'checks' => [
+                'consent_validity' => ['enabled' => true, 'severity' => 'high'],
+                'consent_expiration' => ['enabled' => true, 'severity' => 'medium'],
+                'retention_expiration' => ['enabled' => true, 'severity' => 'high'],
+                'retention_policy' => ['enabled' => true, 'severity' => 'medium'],
+                'dsr_timeliness' => ['enabled' => true, 'severity' => 'critical'],
+                'dpia_completion' => ['enabled' => true, 'severity' => 'medium'],
+                'encryption' => ['enabled' => true, 'severity' => 'critical'],
+                'access_control' => ['enabled' => true, 'severity' => 'high'],
+            ],
+            'alert_on_violation' => true,
+            'alert_channels' => ['email', 'slack'],
+            'alert_recipients' => [
+                'critical' => ['dpo@example.com'],
+                'high' => ['compliance@example.com'],
+            ],
+        ],
+
+        // Reporting
+        'reporting' => [
+            'enabled' => true,
+            'storage_disk' => 'local',
+            'storage_path' => 'compliance-reports',
+            'default_format' => 'pdf',
+            'include_pii' => false, // Include PII in reports
+            'retention_days' => 730, // 2 years
+        ],
+
+        // Data Categories (GDPR special categories)
+        'special_categories' => [
+            'racial_ethnic_origin',
+            'political_opinions',
+            'religious_beliefs',
+            'trade_union_membership',
+            'genetic_data',
+            'biometric_data',
+            'health_data',
+            'sex_life_orientation',
+        ],
+
+        // Legal Bases (GDPR Article 6)
+        'legal_bases' => [
+            'consent' => 'Consent (Art. 6(1)(a))',
+            'contract' => 'Contract (Art. 6(1)(b))',
+            'legal_obligation' => 'Legal Obligation (Art. 6(1)(c))',
+            'vital_interests' => 'Vital Interests (Art. 6(1)(d))',
+            'public_interest' => 'Public Interest (Art. 6(1)(e))',
+            'legitimate_interests' => 'Legitimate Interests (Art. 6(1)(f))',
+        ],
+    ],
+];

--- a/config/artisanpack/compliance.php
+++ b/config/artisanpack/compliance.php
@@ -1,8 +1,7 @@
 <?php
 
 return [
-    'compliance' => [
-        'enabled' => env('COMPLIANCE_ENABLED', true),
+    'enabled' => env('COMPLIANCE_ENABLED', true),
 
         // Default regulation to enforce
         'default_regulation' => env('COMPLIANCE_REGULATION', 'gdpr'),
@@ -167,5 +166,4 @@ return [
             'public_interest' => 'Public Interest (Art. 6(1)(e))',
             'legitimate_interests' => 'Legitimate Interests (Art. 6(1)(f))',
         ],
-    ],
 ];

--- a/database/migrations/2025_01_01_100001_create_processing_activities_table.php
+++ b/database/migrations/2025_01_01_100001_create_processing_activities_table.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('processing_activities', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->string('controller_name')->nullable();
+            $table->string('controller_contact')->nullable();
+            $table->string('processor_name')->nullable();
+            $table->string('processor_contact')->nullable();
+            $table->string('dpo_contact')->nullable();
+            $table->json('purposes');
+            $table->json('legal_bases');
+            $table->json('data_categories');
+            $table->json('data_subjects');
+            $table->json('recipients')->nullable();
+            $table->json('third_countries')->nullable();
+            $table->json('safeguards')->nullable();
+            $table->json('retention_policy')->nullable();
+            $table->json('security_measures')->nullable();
+            $table->json('automated_decisions')->nullable();
+            $table->boolean('dpia_required')->default(false);
+            $table->string('dpia_reference', 100)->nullable();
+            $table->enum('status', ['active', 'suspended', 'terminated'])->default('active');
+            $table->timestamp('last_review_at')->nullable();
+            $table->timestamp('next_review_at')->nullable();
+            $table->timestamps();
+
+            $table->index('status');
+            $table->index('dpia_required');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('processing_activities');
+    }
+};

--- a/database/migrations/2025_01_01_100002_create_data_protection_assessments_table.php
+++ b/database/migrations/2025_01_01_100002_create_data_protection_assessments_table.php
@@ -1,0 +1,64 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('data_protection_assessments', function (Blueprint $table) {
+            $table->id();
+            $table->string('assessment_number', 20)->unique();
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->unsignedBigInteger('processing_activity_id')->nullable();
+        
+        $table->foreign('processing_activity_id')
+              ->references('id')
+              ->on('processing_activities')
+              ->onDelete('set null');
+            $table->enum('status', ['draft', 'pending', 'in_review', 'approved', 'rejected', 'revision_required'])->default('draft');
+            $table->unsignedInteger('version')->default(1);
+            $table->unsignedBigInteger('parent_assessment_id')->nullable();
+            $table->foreign('parent_assessment_id')
+                ->references('id')
+                ->on('data_protection_assessments')
+                ->onDelete('set null');
+            $table->json('data_categories')->nullable();
+            $table->json('data_subjects')->nullable();
+            $table->json('processing_purposes')->nullable();
+            $table->json('legal_bases')->nullable();
+            $table->json('recipients')->nullable();
+            $table->json('retention_periods')->nullable();
+            $table->json('transfers')->nullable();
+            $table->json('security_measures')->nullable();
+            $table->decimal('overall_risk_score', 5, 2)->nullable();
+            $table->enum('overall_risk_level', ['low', 'medium', 'high', 'critical'])->nullable();
+            $table->text('dpo_opinion')->nullable();
+            $table->timestamp('dpo_reviewed_at')->nullable();
+            $table->unsignedBigInteger('dpo_reviewed_by')->nullable();
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->unsignedBigInteger('reviewed_by')->nullable();
+            $table->timestamp('approved_at')->nullable();
+            $table->timestamp('next_review_at')->nullable();
+            $table->timestamps();
+
+            $table->index('status');
+            $table->index('processing_activity_id');
+            $table->index('overall_risk_level');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('data_protection_assessments');
+    }
+};

--- a/database/migrations/2025_01_01_100003_create_assessment_risks_table.php
+++ b/database/migrations/2025_01_01_100003_create_assessment_risks_table.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('assessment_risks', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('assessment_id');
+            $table->string('risk_category', 50);
+            $table->string('risk_title');
+            $table->text('risk_description')->nullable();
+            $table->enum('likelihood', ['rare', 'unlikely', 'possible', 'likely', 'almost_certain']);
+            $table->enum('impact', ['negligible', 'minor', 'moderate', 'major', 'severe']);
+            $table->decimal('inherent_score', 5, 2)->nullable();
+            $table->decimal('residual_score', 5, 2)->nullable();
+            $table->enum('risk_level', ['low', 'medium', 'high', 'critical'])->nullable();
+            $table->unsignedBigInteger('risk_owner')->nullable();
+            $table->enum('status', ['identified', 'mitigating', 'mitigated', 'accepted'])->default('identified');
+            $table->unsignedBigInteger('accepted_by')->nullable();
+            $table->timestamp('accepted_at')->nullable();
+            $table->text('acceptance_justification')->nullable();
+            $table->timestamps();
+
+            $table->index('assessment_id');
+            $table->index('risk_level');
+
+            $table->foreign('assessment_id')
+                ->references('id')
+                ->on('data_protection_assessments')
+                ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('assessment_risks');
+    }
+};

--- a/database/migrations/2025_01_01_100004_create_risk_mitigations_table.php
+++ b/database/migrations/2025_01_01_100004_create_risk_mitigations_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('risk_mitigations', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('risk_id');
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->enum('type', ['technical', 'organizational', 'contractual']);
+            $table->enum('status', ['planned', 'in_progress', 'implemented', 'verified'])->default('planned');
+            $table->enum('priority', ['low', 'medium', 'high', 'critical'])->default('medium');
+            $table->unsignedBigInteger('assigned_to')->nullable();
+            $table->date('due_date')->nullable();
+            $table->timestamp('implemented_at')->nullable();
+            $table->timestamp('verified_at')->nullable();
+            $table->unsignedBigInteger('verified_by')->nullable();
+            $table->unsignedTinyInteger('effectiveness_rating')->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+
+            $table->index('risk_id');
+            $table->index('status');
+
+            $table->foreign('risk_id')
+                ->references('id')
+                ->on('assessment_risks')
+                ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('risk_mitigations');
+    }
+};

--- a/database/migrations/2025_01_01_100005_create_consent_policies_table.php
+++ b/database/migrations/2025_01_01_100005_create_consent_policies_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('consent_policies', function (Blueprint $table) {
+            $table->id();
+            $table->string('purpose', 100);
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->text('legal_text');
+            $table->string('version', 20);
+            $table->unsignedBigInteger('previous_version_id')->nullable();
+            $table->json('data_categories')->nullable();
+            $table->json('processing_details')->nullable();
+            $table->string('retention_period', 100)->nullable();
+            $table->json('third_party_sharing')->nullable();
+            $table->text('rights_description')->nullable();
+            $table->text('withdrawal_consequences')->nullable();
+            $table->boolean('is_required')->default(false);
+            $table->boolean('is_active')->default(true);
+            $table->boolean('requires_explicit')->default(true);
+            $table->unsignedTinyInteger('minimum_age')->default(16);
+            $table->timestamp('effective_at');
+            $table->timestamp('expires_at')->nullable();
+            $table->json('changes_from_previous')->nullable();
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->timestamps();
+
+            $table->unique(['purpose', 'version']);
+            $table->index(['is_active', 'purpose']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('consent_policies');
+    }
+};

--- a/database/migrations/2025_01_01_100006_create_consent_records_table.php
+++ b/database/migrations/2025_01_01_100006_create_consent_records_table.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('consent_records', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id');
+            $table->string('purpose', 100);
+            $table->unsignedBigInteger('policy_id');
+            $table->string('policy_version', 20);
+            $table->enum('status', ['granted', 'withdrawn', 'expired']);
+            $table->enum('consent_type', ['explicit', 'implied']);
+            $table->string('collection_method', 50);
+            $table->json('collection_context')->nullable();
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->string('proof_reference')->nullable();
+            $table->json('granular_choices')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamp('withdrawn_at')->nullable();
+            $table->text('withdrawal_reason')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+
+            $table->index(['user_id', 'purpose']);
+            $table->index('status');
+            $table->index('expires_at');
+
+            $table->foreign('policy_id')
+                ->references('id')
+                ->on('consent_policies')
+                ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('consent_records');
+    }
+};

--- a/database/migrations/2025_01_01_100006_create_consent_records_table.php
+++ b/database/migrations/2025_01_01_100006_create_consent_records_table.php
@@ -25,6 +25,7 @@ return new class extends Migration
             $table->text('user_agent')->nullable();
             $table->string('proof_reference')->nullable();
             $table->json('granular_choices')->nullable();
+            $table->timestamp('granted_at')->nullable();
             $table->timestamp('expires_at')->nullable();
             $table->timestamp('withdrawn_at')->nullable();
             $table->text('withdrawal_reason')->nullable();

--- a/database/migrations/2025_01_01_100007_create_consent_audit_logs_table.php
+++ b/database/migrations/2025_01_01_100007_create_consent_audit_logs_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('consent_audit_logs', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('consent_record_id')->nullable();
+            $table->unsignedBigInteger('user_id');
+            $table->enum('action', ['granted', 'withdrawn', 'expired', 'policy_updated']);
+            $table->string('purpose', 100);
+            $table->string('old_status', 20)->nullable();
+            $table->string('new_status', 20)->nullable();
+            $table->string('policy_version', 20)->nullable();
+            $table->enum('actor_type', ['user', 'system', 'admin']);
+            $table->unsignedBigInteger('actor_id')->nullable();
+            $table->text('reason')->nullable();
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+
+            $table->index('user_id');
+            $table->index('consent_record_id');
+            $table->index('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('consent_audit_logs');
+    }
+};

--- a/database/migrations/2025_01_01_100008_create_erasure_requests_table.php
+++ b/database/migrations/2025_01_01_100008_create_erasure_requests_table.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('erasure_requests', function (Blueprint $table) {
+            $table->id();
+            $table->string('request_number', 20)->unique();
+            $table->unsignedBigInteger('user_id');
+            $table->enum('requester_type', ['self', 'guardian', 'authorized_agent'])->default('self');
+            $table->string('requester_contact')->nullable();
+            $table->enum('status', ['pending', 'verifying', 'approved', 'processing', 'completed', 'rejected'])->default('pending');
+            $table->enum('scope', ['full', 'partial'])->default('full');
+            $table->json('specific_data')->nullable();
+            $table->text('reason')->nullable();
+            $table->boolean('identity_verified')->default(false);
+            $table->timestamp('identity_verified_at')->nullable();
+            $table->string('identity_verified_method', 50)->nullable();
+            $table->json('exemptions_found')->nullable();
+            $table->text('exemption_explanation')->nullable();
+            $table->json('handlers_processed')->nullable();
+            $table->json('handlers_failed')->nullable();
+            $table->json('third_parties_notified')->nullable();
+            $table->string('certificate_path', 500)->nullable();
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamp('rejected_at')->nullable();
+            $table->unsignedBigInteger('rejected_by')->nullable();
+            $table->text('rejection_reason')->nullable();
+            $table->timestamp('deadline_at');
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->unsignedBigInteger('processed_by')->nullable();
+            $table->timestamps();
+
+            $table->index('user_id');
+            $table->index('status');
+            $table->index('deadline_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('erasure_requests');
+    }
+};

--- a/database/migrations/2025_01_01_100009_create_erasure_logs_table.php
+++ b/database/migrations/2025_01_01_100009_create_erasure_logs_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('erasure_logs', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('request_id');
+            $table->string('handler_name', 100);
+            $table->enum('action', ['find', 'erase', 'verify', 'rollback']);
+            $table->enum('status', ['success', 'failed', 'skipped']);
+            $table->unsignedInteger('records_found')->default(0);
+            $table->unsignedInteger('records_erased')->default(0);
+            $table->unsignedInteger('records_retained')->default(0);
+            $table->text('retention_reason')->nullable();
+            $table->string('backup_reference')->nullable();
+            $table->text('error_message')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamp('started_at');
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamps();
+
+            $table->index('request_id');
+
+            $table->foreign('request_id')
+                ->references('id')
+                ->on('erasure_requests')
+                ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('erasure_logs');
+    }
+};

--- a/database/migrations/2025_01_01_100010_add_pending_status_to_data_protection_assessments.php
+++ b/database/migrations/2025_01_01_100010_add_pending_status_to_data_protection_assessments.php
@@ -1,0 +1,78 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * This migration adds the 'pending' status to existing databases.
+ *
+ * Note: For new installations, the 'pending' status is already included in the
+ * original table creation migration (2025_01_01_100002). This migration ensures
+ * that databases created before the 'pending' status was added are updated.
+ */
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // For MySQL/MariaDB - check if 'pending' already exists before modifying
+        if (DB::getDriverName() === 'mysql') {
+            // Check if 'pending' is already in the enum
+            $columnType = DB::selectOne(
+                "SELECT COLUMN_TYPE FROM INFORMATION_SCHEMA.COLUMNS
+                 WHERE TABLE_SCHEMA = DATABASE()
+                 AND TABLE_NAME = 'data_protection_assessments'
+                 AND COLUMN_NAME = 'status'"
+            );
+
+            if ($columnType && ! str_contains($columnType->COLUMN_TYPE, "'pending'")) {
+                DB::statement("ALTER TABLE data_protection_assessments MODIFY COLUMN status ENUM('draft', 'pending', 'in_review', 'approved', 'rejected', 'revision_required') DEFAULT 'draft'");
+            }
+        }
+
+        // For PostgreSQL - IF NOT EXISTS handles idempotency
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement("ALTER TYPE data_protection_assessments_status_type ADD VALUE IF NOT EXISTS 'pending' AFTER 'draft'");
+        }
+
+        // For SQLite - no action needed (enums are stored as text)
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * WARNING: Removing enum values can cause data loss if records exist with
+     * the 'pending' status. This rollback will fail if such records exist.
+     *
+     * PostgreSQL Note: PostgreSQL does not support removing enum values directly.
+     * To rollback in PostgreSQL, you would need to:
+     * 1. Create a new enum type without 'pending'
+     * 2. Migrate all 'pending' records to another status (e.g., 'draft')
+     * 3. Alter the column to use the new enum type
+     * 4. Drop the old enum type
+     * This is intentionally not automated due to the complexity and risk of data loss.
+     */
+    public function down(): void
+    {
+        // Check for existing 'pending' records before attempting rollback
+        $pendingCount = DB::table('data_protection_assessments')
+            ->where('status', 'pending')
+            ->count();
+
+        if ($pendingCount > 0) {
+            throw new \RuntimeException(
+                "Cannot rollback: {$pendingCount} records have 'pending' status. ".
+                "Update these records to a different status before rolling back."
+            );
+        }
+
+        if (DB::getDriverName() === 'mysql') {
+            DB::statement("ALTER TABLE data_protection_assessments MODIFY COLUMN status ENUM('draft', 'in_review', 'approved', 'rejected', 'revision_required') DEFAULT 'draft'");
+        }
+
+        // PostgreSQL: Manual intervention required (see docblock above)
+        // SQLite: No action needed
+    }
+};

--- a/database/migrations/2025_01_01_100010_create_portability_requests_table.php
+++ b/database/migrations/2025_01_01_100010_create_portability_requests_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('portability_requests', function (Blueprint $table) {
+            $table->id();
+            $table->string('request_number', 20)->unique();
+            $table->unsignedBigInteger('user_id');
+            $table->enum('requester_type', ['self', 'guardian', 'authorized_agent'])->default('self');
+            $table->enum('status', ['pending', 'processing', 'completed', 'failed', 'expired'])->default('pending');
+            $table->enum('format', ['json', 'xml', 'csv'])->default('json');
+            $table->json('categories')->nullable();
+            $table->enum('transfer_type', ['download', 'direct_transfer'])->default('download');
+            $table->string('destination_url', 500)->nullable();
+            $table->boolean('destination_verified')->default(false);
+            $table->string('file_path', 500)->nullable();
+            $table->unsignedBigInteger('file_size')->nullable();
+            $table->string('file_hash', 64)->nullable();
+            $table->unsignedInteger('download_count')->default(0);
+            $table->unsignedInteger('download_limit')->default(5);
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamp('downloaded_at')->nullable();
+            $table->timestamp('deadline_at');
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->timestamps();
+
+            $table->index('user_id');
+            $table->index('status');
+            $table->index('expires_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('portability_requests');
+    }
+};

--- a/database/migrations/2025_01_01_100011_add_suspension_columns_to_processing_activities.php
+++ b/database/migrations/2025_01_01_100011_add_suspension_columns_to_processing_activities.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('processing_activities', function (Blueprint $table) {
+            $table->string('suspension_reason')->nullable()->after('status');
+            $table->timestamp('suspended_at')->nullable()->after('suspension_reason');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('processing_activities', function (Blueprint $table) {
+            $table->dropColumn(['suspension_reason', 'suspended_at']);
+        });
+    }
+};

--- a/database/migrations/2025_01_01_100011_create_export_schemas_table.php
+++ b/database/migrations/2025_01_01_100011_create_export_schemas_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('export_schemas', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 100);
+            $table->string('category', 50);
+            $table->string('version', 20);
+            $table->enum('format', ['json', 'xml']);
+            $table->json('schema_definition');
+            $table->json('field_mappings')->nullable();
+            $table->json('transformations')->nullable();
+            $table->boolean('is_default')->default(false);
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+
+            $table->unique(['category', 'version', 'format']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('export_schemas');
+    }
+};

--- a/database/migrations/2025_01_01_100012_create_retention_policies_table.php
+++ b/database/migrations/2025_01_01_100012_create_retention_policies_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('retention_policies', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 100);
+            $table->text('description')->nullable();
+            $table->string('model_class')->nullable();
+            $table->string('data_category', 50)->nullable();
+            $table->unsignedInteger('retention_days')->nullable();
+            $table->text('legal_basis')->nullable();
+            $table->enum('deletion_strategy', ['delete', 'anonymize', 'archive'])->default('delete');
+            $table->string('archive_location')->nullable();
+            $table->json('conditions')->nullable();
+            $table->json('exceptions')->nullable();
+            $table->unsignedInteger('notification_days')->default(30);
+            $table->boolean('is_active')->default(true);
+            $table->unsignedBigInteger('created_by')->nullable();
+            $table->timestamps();
+
+            $table->index('model_class');
+            $table->index('is_active');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('retention_policies');
+    }
+};

--- a/database/migrations/2025_01_01_100013_create_collection_policies_table.php
+++ b/database/migrations/2025_01_01_100013_create_collection_policies_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('collection_policies', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 100);
+            $table->string('purpose', 100)->unique();
+            $table->json('allowed_fields')->nullable();
+            $table->json('required_fields')->nullable();
+            $table->json('conditional_fields')->nullable();
+            $table->json('prohibited_fields')->nullable();
+            $table->text('legal_basis')->nullable();
+            $table->enum('consent_type', ['explicit', 'implied', 'not_required'])->default('explicit');
+            $table->json('minimization_rules')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+
+            $table->index('purpose');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('collection_policies');
+    }
+};

--- a/database/migrations/2025_01_01_100014_create_compliance_violations_table.php
+++ b/database/migrations/2025_01_01_100014_create_compliance_violations_table.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('compliance_violations', function (Blueprint $table) {
+            $table->id();
+            $table->string('violation_number', 20)->unique();
+            $table->string('check_name', 100);
+            $table->string('category', 50);
+            $table->string('regulation', 50)->nullable();
+            $table->string('article_reference', 50)->nullable();
+            $table->enum('severity', ['info', 'low', 'medium', 'high', 'critical']);
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->json('affected_records')->nullable();
+            $table->unsignedInteger('affected_count')->default(0);
+            $table->json('evidence')->nullable();
+            $table->json('remediation_steps')->nullable();
+            $table->timestamp('remediation_deadline')->nullable();
+            $table->enum('status', ['open', 'acknowledged', 'in_progress', 'resolved', 'accepted'])->default('open');
+            $table->unsignedBigInteger('assigned_to')->nullable();
+            $table->timestamp('acknowledged_at')->nullable();
+            $table->unsignedBigInteger('acknowledged_by')->nullable();
+            $table->timestamp('resolved_at')->nullable();
+            $table->unsignedBigInteger('resolved_by')->nullable();
+            $table->text('resolution_notes')->nullable();
+            $table->boolean('accepted_risk')->default(false);
+            $table->unsignedBigInteger('risk_acceptance_by')->nullable();
+            $table->text('risk_acceptance_reason')->nullable();
+            $table->timestamps();
+
+            $table->index(['status', 'severity']);
+            $table->index('check_name');
+            $table->index('regulation');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('compliance_violations');
+    }
+};

--- a/database/migrations/2025_01_01_100015_create_compliance_check_results_table.php
+++ b/database/migrations/2025_01_01_100015_create_compliance_check_results_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('compliance_check_results', function (Blueprint $table) {
+            $table->id();
+            $table->string('check_name', 100);
+            $table->enum('status', ['passed', 'failed', 'warning', 'error']);
+            $table->decimal('score', 5, 2)->nullable();
+            $table->unsignedInteger('violations_found')->default(0);
+            $table->unsignedInteger('warnings_found')->default(0);
+            $table->unsignedInteger('items_checked')->default(0);
+            $table->unsignedInteger('items_compliant')->default(0);
+            $table->json('details')->nullable();
+            $table->unsignedInteger('execution_time_ms')->nullable();
+            $table->timestamp('next_run_at')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+
+            $table->index('check_name');
+            $table->index('status');
+            $table->index('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('compliance_check_results');
+    }
+};

--- a/database/migrations/2025_01_01_100016_create_compliance_scores_table.php
+++ b/database/migrations/2025_01_01_100016_create_compliance_scores_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('compliance_scores', function (Blueprint $table) {
+            $table->id();
+            $table->decimal('overall_score', 5, 2);
+            $table->string('regulation', 50)->default('all');
+            $table->json('category_scores')->nullable();
+            $table->json('findings')->nullable();
+            $table->json('recommendations')->nullable();
+            $table->timestamp('calculated_at');
+            $table->timestamp('next_calculation_at')->nullable();
+            $table->string('calculated_by', 50)->nullable();
+            $table->timestamps();
+
+            $table->index('regulation');
+            $table->index('calculated_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('compliance_scores');
+    }
+};

--- a/database/migrations/2025_01_01_100017_create_scheduled_compliance_reports_table.php
+++ b/database/migrations/2025_01_01_100017_create_scheduled_compliance_reports_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('scheduled_compliance_reports', function (Blueprint $table) {
+            $table->id();
+            $table->string('report_type', 50);
+            $table->string('name', 100);
+            $table->string('cron_expression', 100);
+            $table->json('recipients');
+            $table->json('options')->nullable();
+            $table->enum('format', ['pdf', 'html', 'csv', 'json'])->default('pdf');
+            $table->boolean('is_active')->default(true);
+            $table->timestamp('last_run_at')->nullable();
+            $table->timestamp('next_run_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['is_active', 'next_run_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('scheduled_compliance_reports');
+    }
+};

--- a/database/migrations/2025_01_01_100018_add_unique_granted_consent_index.php
+++ b/database/migrations/2025_01_01_100018_add_unique_granted_consent_index.php
@@ -1,0 +1,122 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * This migration adds a unique partial index to prevent concurrent
+     * supersede race conditions where two grant calls for the same
+     * user/purpose can both read the same existing record.
+     *
+     * For PostgreSQL: Uses a proper partial index
+     * For MySQL/MariaDB: Uses a generated column approach
+     * For SQLite: Uses a unique index with expression
+     */
+    public function up(): void
+    {
+        $driver = Schema::getConnection()->getDriverName();
+
+        match ($driver) {
+            'pgsql' => $this->createPostgresIndex(),
+            'mysql', 'mariadb' => $this->createMySqlIndex(),
+            'sqlite' => $this->createSqliteIndex(),
+            default => $this->createPostgresIndex(), // Fallback to PostgreSQL syntax
+        };
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $driver = Schema::getConnection()->getDriverName();
+
+        match ($driver) {
+            'pgsql' => $this->dropPostgresIndex(),
+            'mysql', 'mariadb' => $this->dropMySqlIndex(),
+            'sqlite' => $this->dropSqliteIndex(),
+            default => $this->dropPostgresIndex(),
+        };
+    }
+
+    /**
+     * Create PostgreSQL partial unique index.
+     */
+    protected function createPostgresIndex(): void
+    {
+        DB::statement("
+            CREATE UNIQUE INDEX consent_records_user_purpose_granted_unique
+            ON consent_records (user_id, purpose)
+            WHERE status = 'granted'
+        ");
+    }
+
+    /**
+     * Drop PostgreSQL partial unique index.
+     */
+    protected function dropPostgresIndex(): void
+    {
+        DB::statement('DROP INDEX IF EXISTS consent_records_user_purpose_granted_unique');
+    }
+
+    /**
+     * Create MySQL/MariaDB unique index using a generated column.
+     *
+     * MySQL doesn't support partial indexes, so we use a generated column
+     * that is NULL for non-granted records (NULL values don't violate unique constraints).
+     */
+    protected function createMySqlIndex(): void
+    {
+        // Add a generated column that's only populated for granted records
+        DB::statement("
+            ALTER TABLE consent_records
+            ADD COLUMN granted_unique_key VARCHAR(255)
+            GENERATED ALWAYS AS (
+                CASE WHEN status = 'granted'
+                    THEN CONCAT(user_id, ':', purpose)
+                    ELSE NULL
+                END
+            ) STORED
+        ");
+
+        // Add unique index on the generated column
+        DB::statement('
+            CREATE UNIQUE INDEX consent_records_granted_unique_key
+            ON consent_records (granted_unique_key)
+        ');
+    }
+
+    /**
+     * Drop MySQL/MariaDB unique index and generated column.
+     */
+    protected function dropMySqlIndex(): void
+    {
+        DB::statement('DROP INDEX consent_records_granted_unique_key ON consent_records');
+        DB::statement('ALTER TABLE consent_records DROP COLUMN granted_unique_key');
+    }
+
+    /**
+     * Create SQLite unique index using expression.
+     */
+    protected function createSqliteIndex(): void
+    {
+        DB::statement("
+            CREATE UNIQUE INDEX consent_records_user_purpose_granted_unique
+            ON consent_records (user_id, purpose)
+            WHERE status = 'granted'
+        ");
+    }
+
+    /**
+     * Drop SQLite unique index.
+     */
+    protected function dropSqliteIndex(): void
+    {
+        DB::statement('DROP INDEX IF EXISTS consent_records_user_purpose_granted_unique');
+    }
+};

--- a/routes/compliance.php
+++ b/routes/compliance.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+use ArtisanPackUI\Compliance\Http\Controllers\Compliance\ConsentController;
+use ArtisanPackUI\Compliance\Http\Controllers\Compliance\ErasureController;
+use ArtisanPackUI\Compliance\Http\Controllers\Compliance\PortabilityController;
+use ArtisanPackUI\Compliance\Http\Controllers\Compliance\ComplianceDashboardController;
+use Illuminate\Support\Facades\Route;
+
+/*
+|--------------------------------------------------------------------------
+| Compliance Routes
+|--------------------------------------------------------------------------
+|
+| These routes handle GDPR/CCPA compliance features including consent
+| management, data erasure (right to be forgotten), and data portability.
+|
+*/
+
+Route::middleware(config('artisanpack.compliance.routes.middleware', ['web', 'auth']))
+    ->prefix(config('artisanpack.compliance.routes.prefix', 'compliance'))
+    ->name('compliance.')
+    ->group(function () {
+
+        // Consent Management
+        Route::prefix('consent')->name('consent.')->group(function () {
+            Route::get('/', [ConsentController::class, 'index'])->name('index');
+            Route::get('/policies', [ConsentController::class, 'policies'])->name('policies');
+            Route::get('/policies/{policy}', [ConsentController::class, 'showPolicy'])->name('policies.show');
+            Route::post('/grant', [ConsentController::class, 'grant'])->name('grant');
+            Route::post('/withdraw', [ConsentController::class, 'withdraw'])->name('withdraw');
+            Route::get('/history', [ConsentController::class, 'history'])->name('history');
+            Route::get('/verify/{policy}', [ConsentController::class, 'verify'])->name('verify');
+        });
+
+        // Data Erasure (Right to be Forgotten)
+        Route::prefix('erasure')->name('erasure.')->group(function () {
+            Route::get('/', [ErasureController::class, 'index'])->name('index');
+            Route::post('/request', [ErasureController::class, 'request'])->name('request');
+            Route::get('/status/{request}', [ErasureController::class, 'status'])->name('status');
+            Route::post('/cancel/{request}', [ErasureController::class, 'cancel'])->name('cancel');
+        });
+
+        // Data Portability
+        Route::prefix('portability')->name('portability.')->group(function () {
+            Route::get('/', [PortabilityController::class, 'index'])->name('index');
+            Route::post('/request', [PortabilityController::class, 'request'])->name('request');
+            Route::get('/status/{request}', [PortabilityController::class, 'status'])->name('status');
+            Route::get('/download/{request}', [PortabilityController::class, 'download'])->name('download');
+        });
+
+        // Compliance Dashboard (Admin only)
+        Route::middleware(config('artisanpack.compliance.routes.admin_middleware', ['can:viewComplianceDashboard']))
+            ->prefix('dashboard')
+            ->name('dashboard.')
+            ->group(function () {
+                Route::get('/', [ComplianceDashboardController::class, 'index'])->name('index');
+                Route::get('/violations', [ComplianceDashboardController::class, 'violations'])->name('violations');
+                Route::get('/violations/{violation}', [ComplianceDashboardController::class, 'showViolation'])->name('violations.show');
+                Route::post('/violations/{violation}/resolve', [ComplianceDashboardController::class, 'resolveViolation'])->name('violations.resolve');
+                Route::get('/dsr-requests', [ComplianceDashboardController::class, 'dsrRequests'])->name('dsr-requests');
+                Route::get('/consent-overview', [ComplianceDashboardController::class, 'consentOverview'])->name('consent-overview');
+                Route::get('/dpia', [ComplianceDashboardController::class, 'dpiaOverview'])->name('dpia');
+                Route::get('/reports', [ComplianceDashboardController::class, 'reports'])->name('reports');
+                Route::post('/reports/generate', [ComplianceDashboardController::class, 'generateReport'])->name('reports.generate');
+                Route::get('/reports/{report}/download', [ComplianceDashboardController::class, 'downloadReport'])->name('reports.download');
+            });
+    });
+
+// Public cookie consent routes (no auth required)
+Route::middleware(config('artisanpack.compliance.routes.public_middleware', ['web']))
+    ->prefix(config('artisanpack.compliance.routes.prefix', 'compliance'))
+    ->name('compliance.')
+    ->group(function () {
+        Route::get('/cookies/preferences', [ConsentController::class, 'cookiePreferences'])->name('cookies.preferences');
+        Route::post('/cookies/save', [ConsentController::class, 'saveCookiePreferences'])->name('cookies.save');
+    });

--- a/src/Compliance/Assessment/DpiaService.php
+++ b/src/Compliance/Assessment/DpiaService.php
@@ -196,7 +196,7 @@ class DpiaService
     public function isRequired( ProcessingActivity $activity ): bool
     {
         // Check for special categories
-        $specialCategories = config( 'artisanpack.compliance.compliance.special_categories', [] );
+        $specialCategories = config( 'artisanpack.compliance.special_categories', [] );
         $dataCategories    = $activity->data_categories ?? [];
 
         foreach ( $dataCategories as $category ) {

--- a/src/Compliance/Assessment/DpiaService.php
+++ b/src/Compliance/Assessment/DpiaService.php
@@ -1,0 +1,296 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Assessment;
+
+use ArtisanPackUI\Compliance\Models\AssessmentRisk;
+use ArtisanPackUI\Compliance\Models\DataProtectionAssessment;
+use ArtisanPackUI\Compliance\Models\ProcessingActivity;
+use ArtisanPackUI\Compliance\Models\RiskMitigation;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class DpiaService
+{
+    protected RiskCalculator $riskCalculator;
+
+    public function __construct( RiskCalculator $riskCalculator )
+    {
+        $this->riskCalculator = $riskCalculator;
+    }
+
+    /**
+     * Create a new DPIA.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function create( array $data ): DataProtectionAssessment
+    {
+        return DataProtectionAssessment::create( [
+            'title'                  => $data['title'],
+            'description'            => $data['description'] ?? null,
+            'processing_activity_id' => $data['processing_activity_id'] ?? null,
+            'status'                 => 'draft',
+            'version'                => 1,
+            'data_categories'        => $data['data_categories'] ?? [],
+            'data_subjects'          => $data['data_subjects'] ?? [],
+            'processing_purposes'    => $data['processing_purposes'] ?? [],
+            'legal_bases'            => $data['legal_bases'] ?? [],
+            'recipients'             => $data['recipients'] ?? [],
+            'retention_periods'      => $data['retention_periods'] ?? [],
+            'transfers'              => $data['transfers'] ?? [],
+            'security_measures'      => $data['security_measures'] ?? [],
+            'created_by'             => auth()->id(),
+        ] );
+    }
+
+    /**
+     * Create revision of an existing DPIA.
+     */
+    public function createRevision( DataProtectionAssessment $assessment ): DataProtectionAssessment
+    {
+        return DB::transaction( function () use ( $assessment ) {
+            $newVersion = $assessment->version + 1;
+
+            return DataProtectionAssessment::create( [
+                'title'                  => $assessment->title,
+                'description'            => $assessment->description,
+                'processing_activity_id' => $assessment->processing_activity_id,
+                'status'                 => 'draft',
+                'version'                => $newVersion,
+                'parent_assessment_id'   => $assessment->id,
+                'data_categories'        => $assessment->data_categories,
+                'data_subjects'          => $assessment->data_subjects,
+                'processing_purposes'    => $assessment->processing_purposes,
+                'legal_bases'            => $assessment->legal_bases,
+                'recipients'             => $assessment->recipients,
+                'retention_periods'      => $assessment->retention_periods,
+                'transfers'              => $assessment->transfers,
+                'security_measures'      => $assessment->security_measures,
+                'created_by'             => auth()->id(),
+            ] );
+        } );
+    }
+
+    /**
+     * Add a risk to the assessment.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function addRisk( DataProtectionAssessment $assessment, array $data ): AssessmentRisk
+    {
+        $risk = new AssessmentRisk( [
+            'assessment_id'    => $assessment->id,
+            'risk_category'    => $data['risk_category'],
+            'risk_title'       => $data['risk_title'],
+            'risk_description' => $data['risk_description'] ?? null,
+            'likelihood'       => $data['likelihood'],
+            'impact'           => $data['impact'],
+            'risk_owner'       => $data['risk_owner'] ?? null,
+            'status'           => 'identified',
+        ] );
+
+        // Calculate scores
+        $risk->inherent_score = $risk->calculateInherentScore();
+        $risk->risk_level     = AssessmentRisk::determineRiskLevel( $risk->inherent_score );
+        $risk->save();
+
+        // Recalculate overall risk
+        $this->recalculateOverallRisk( $assessment );
+
+        return $risk;
+    }
+
+    /**
+     * Add a mitigation to a risk.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function addMitigation( AssessmentRisk $risk, array $data ): RiskMitigation
+    {
+        return RiskMitigation::create( [
+            'risk_id'     => $risk->id,
+            'title'       => $data['title'],
+            'description' => $data['description'] ?? null,
+            'type'        => $data['type'],
+            'status'      => 'planned',
+            'priority'    => $data['priority'] ?? 'medium',
+            'assigned_to' => $data['assigned_to'] ?? null,
+            'due_date'    => $data['due_date'] ?? null,
+        ] );
+    }
+
+    /**
+     * Submit assessment for review.
+     */
+    public function submitForReview( DataProtectionAssessment $assessment ): DataProtectionAssessment
+    {
+        $assessment->update( [
+            'status' => 'in_review',
+        ] );
+
+        return $assessment;
+    }
+
+    /**
+     * Record DPO review.
+     */
+    public function recordDpoReview( DataProtectionAssessment $assessment, string $opinion ): DataProtectionAssessment
+    {
+        $assessment->update( [
+            'dpo_opinion'     => $opinion,
+            'dpo_reviewed_at' => now(),
+            'dpo_reviewed_by' => auth()->id(),
+        ] );
+
+        return $assessment;
+    }
+
+    /**
+     * Approve the assessment.
+     */
+    public function approve( DataProtectionAssessment $assessment ): DataProtectionAssessment
+    {
+        $assessment->update( [
+            'status'         => 'approved',
+            'approved_at'    => now(),
+            'reviewed_by'    => auth()->id(),
+            'next_review_at' => now()->addYear(),
+        ] );
+
+        return $assessment;
+    }
+
+    /**
+     * Reject the assessment.
+     */
+    public function reject( DataProtectionAssessment $assessment, string $reason ): DataProtectionAssessment
+    {
+        $assessment->update( [
+            'status'      => 'rejected',
+            'dpo_opinion' => $reason,
+            'reviewed_by' => auth()->id(),
+        ] );
+
+        return $assessment;
+    }
+
+    /**
+     * Request revision.
+     */
+    public function requestRevision( DataProtectionAssessment $assessment, string $reason ): DataProtectionAssessment
+    {
+        $assessment->update( [
+            'status'      => 'revision_required',
+            'dpo_opinion' => $reason,
+            'reviewed_by' => auth()->id(),
+        ] );
+
+        return $assessment;
+    }
+
+    /**
+     * Check if processing activity requires DPIA.
+     */
+    public function isRequired( ProcessingActivity $activity ): bool
+    {
+        // Check for special categories
+        $specialCategories = config( 'artisanpack.compliance.compliance.special_categories', [] );
+        $dataCategories    = $activity->data_categories ?? [];
+
+        foreach ( $dataCategories as $category ) {
+            if ( in_array( $category, $specialCategories ) ) {
+                return true;
+            }
+        }
+
+        // Check for large scale processing
+        $subjects = $activity->data_subjects ?? [];
+        if ( in_array( 'large_scale', $subjects ) ) {
+            return true;
+        }
+
+        // Check for systematic monitoring
+        $purposes = $activity->purposes ?? [];
+        if ( in_array( 'systematic_monitoring', $purposes ) ) {
+            return true;
+        }
+
+        // Check for automated decision making
+        if ( ! empty( $activity->automated_decisions ) ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Get assessments due for review.
+     */
+    public function getDueForReview(): Collection
+    {
+        return DataProtectionAssessment::approved()
+            ->where( 'next_review_at', '<=', now() )
+            ->get();
+    }
+
+    /**
+     * Get high risk assessments.
+     */
+    public function getHighRisk(): Collection
+    {
+        return DataProtectionAssessment::highRisk()->get();
+    }
+
+    /**
+     * Generate assessment summary.
+     *
+     * @return array<string, mixed>
+     */
+    public function generateSummary( DataProtectionAssessment $assessment ): array
+    {
+        $risks = $assessment->risks;
+
+        return [
+            'assessment' => [
+                'number'             => $assessment->assessment_number,
+                'title'              => $assessment->title,
+                'status'             => $assessment->status,
+                'version'            => $assessment->version,
+                'overall_risk_level' => $assessment->overall_risk_level,
+                'overall_risk_score' => $assessment->overall_risk_score,
+            ],
+            'risks' => [
+                'total'     => $risks->count(),
+                'by_level'  => $risks->groupBy( 'risk_level' )->map->count(),
+                'mitigated' => $risks->where( 'status', 'mitigated' )->count(),
+                'accepted'  => $risks->where( 'status', 'accepted' )->count(),
+            ],
+            'mitigations' => [
+                'total'       => $risks->flatMap->mitigations->count(),
+                'implemented' => $risks->flatMap->mitigations->where( 'status', 'implemented' )->count(),
+                'overdue'     => $risks->flatMap->mitigations->filter->isOverdue()->count(),
+            ],
+            'processing' => [
+                'categories' => count( $assessment->data_categories ?? [] ),
+                'subjects'   => count( $assessment->data_subjects ?? [] ),
+                'purposes'   => count( $assessment->processing_purposes ?? [] ),
+            ],
+        ];
+    }
+
+    /**
+     * Recalculate overall risk score.
+     */
+    protected function recalculateOverallRisk( DataProtectionAssessment $assessment ): void
+    {
+        $assessment->refresh();
+        $result = $this->riskCalculator->calculateOverallRisk( $assessment->risks );
+
+        $assessment->update( [
+            'overall_risk_score' => $result['score'],
+            'overall_risk_level' => $result['level'],
+        ]);
+    }
+}

--- a/src/Compliance/Assessment/ProcessingActivityService.php
+++ b/src/Compliance/Assessment/ProcessingActivityService.php
@@ -1,0 +1,323 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Assessment;
+
+use ArtisanPackUI\Compliance\Models\ProcessingActivity;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
+
+class ProcessingActivityService
+{
+    /**
+     * Array fields that should be validated/normalized.
+     *
+     * @var array<string>
+     */
+    protected array $arrayFields = [
+        'purposes',
+        'legal_bases',
+        'data_categories',
+        'data_subjects',
+        'recipients',
+        'third_countries',
+        'safeguards',
+        'retention_policy',
+        'security_measures',
+        'automated_decisions',
+    ];
+
+    /**
+     * Valid status values.
+     *
+     * @var array<string>
+     */
+    protected array $validStatuses = ['active', 'suspended', 'terminated', 'draft'];
+
+    /**
+     * Create a new processing activity record.
+     *
+     * @param  array<string, mixed>  $data
+     *
+     * @throws ValidationException
+     */
+    public function create( array $data ): ProcessingActivity
+    {
+        $this->validateInput( $data );
+
+        $sanitized = $this->sanitizeData( $data );
+
+        return ProcessingActivity::create( [
+            'name'                => $sanitized['name'],
+            'description'         => $sanitized['description'] ?? null,
+            'controller_name'     => $sanitized['controller_name'] ?? config( 'app.name' ),
+            'controller_contact'  => $sanitized['controller_contact'] ?? null,
+            'processor_name'      => $sanitized['processor_name'] ?? null,
+            'processor_contact'   => $sanitized['processor_contact'] ?? null,
+            'dpo_contact'         => $sanitized['dpo_contact'] ?? null,
+            'purposes'            => $sanitized['purposes'],
+            'legal_bases'         => $sanitized['legal_bases'],
+            'data_categories'     => $sanitized['data_categories'],
+            'data_subjects'       => $sanitized['data_subjects'],
+            'recipients'          => $sanitized['recipients'],
+            'third_countries'     => $sanitized['third_countries'],
+            'safeguards'          => $sanitized['safeguards'],
+            'retention_policy'    => $sanitized['retention_policy'],
+            'security_measures'   => $sanitized['security_measures'],
+            'automated_decisions' => $sanitized['automated_decisions'],
+            'dpia_required'       => $this->determineDpiaRequired( $sanitized ),
+            'status'              => 'active',
+            'next_review_at'      => $sanitized['next_review_at'] ?? now()->addYear(),
+        ] );
+    }
+
+    /**
+     * Update a processing activity.
+     *
+     * @param  array<string, mixed>  $data
+     *
+     * @throws ValidationException
+     */
+    public function update( ProcessingActivity $activity, array $data ): ProcessingActivity
+    {
+        $this->validateInput( $data, true );
+
+        // Recalculate DPIA requirement if data categories, automated_decisions, or purposes changed
+        if ( isset( $data['data_categories'] ) || isset( $data['automated_decisions'] ) || isset( $data['purposes'] ) ) {
+            $data['dpia_required'] = $this->determineDpiaRequired( array_merge(
+                $activity->toArray(),
+                $data,
+            ) );
+        }
+
+        // Merge last_review_at into the data array for a single update
+        $data['last_review_at'] = now();
+
+        $activity->update( $data );
+
+        return $activity;
+    }
+
+    /**
+     * Get all active processing activities.
+     */
+    public function getActive(): Collection
+    {
+        return ProcessingActivity::active()->get();
+    }
+
+    /**
+     * Get activities requiring DPIA.
+     */
+    public function getRequiringDpia(): Collection
+    {
+        return ProcessingActivity::active()
+            ->requiresDpia()
+            ->get();
+    }
+
+    /**
+     * Get activities due for review.
+     */
+    public function getDueForReview(): Collection
+    {
+        return ProcessingActivity::active()
+            ->whereNotNull( 'next_review_at' )
+            ->where( 'next_review_at', '<=', now() )
+            ->get();
+    }
+
+    /**
+     * Search activities.
+     *
+     * @param  array<string, mixed>  $filters
+     */
+    public function search( array $filters = [] ): Collection
+    {
+        $query = ProcessingActivity::query();
+
+        if ( isset( $filters['status'] ) ) {
+            $query->where( 'status', $filters['status'] );
+        }
+
+        if ( isset( $filters['dpia_required'] ) ) {
+            $query->where( 'dpia_required', $filters['dpia_required'] );
+        }
+
+        if ( isset( $filters['purpose'] ) ) {
+            $query->whereJsonContains( 'purposes', $filters['purpose'] );
+        }
+
+        if ( isset( $filters['data_category'] ) ) {
+            $query->whereJsonContains( 'data_categories', $filters['data_category'] );
+        }
+
+        if ( isset( $filters['search'] ) ) {
+            $query->where( function ( $q ) use ( $filters ): void {
+                $q->where( 'name', 'like', '%' . $filters['search'] . '%' )
+                    ->orWhere( 'description', 'like', '%' . $filters['search'] . '%' );
+            } );
+        }
+
+        return $query->get();
+    }
+
+    /**
+     * Generate Records of Processing Activities (ROPA).
+     *
+     * @return array<string, mixed>
+     */
+    public function generateRopa(): array
+    {
+        $activities = ProcessingActivity::active()->get();
+
+        return [
+            'generated_at' => now()->toIso8601String(),
+            'organization' => [
+                'name'        => config( 'app.name' ),
+                'dpo_contact' => config( 'artisanpack.compliance.compliance.dpia.dpo_contact' ),
+            ],
+            'activities' => $activities->map( function ( ProcessingActivity $activity ) {
+                return [
+                    'name'              => $activity->name,
+                    'description'       => $activity->description,
+                    'purposes'          => $activity->purposes,
+                    'legal_bases'       => $activity->legal_bases,
+                    'data_categories'   => $activity->data_categories,
+                    'data_subjects'     => $activity->data_subjects,
+                    'recipients'        => $activity->recipients,
+                    'third_countries'   => $activity->third_countries,
+                    'safeguards'        => $activity->safeguards,
+                    'retention'         => $activity->retention_policy,
+                    'security_measures' => $activity->security_measures,
+                    'dpia_required'     => $activity->dpia_required,
+                    'dpia_reference'    => $activity->dpia_reference,
+                ];
+            } )->toArray(),
+        ];
+    }
+
+    /**
+     * Suspend a processing activity.
+     */
+    public function suspend( ProcessingActivity $activity, string $reason ): ProcessingActivity
+    {
+        $activity->update( [
+            'status'            => 'suspended',
+            'suspension_reason' => $reason,
+            'suspended_at'      => now(),
+        ] );
+
+        return $activity;
+    }
+
+    /**
+     * Terminate a processing activity.
+     */
+    public function terminate( ProcessingActivity $activity ): ProcessingActivity
+    {
+        $activity->update( [
+            'status' => 'terminated',
+        ] );
+
+        return $activity;
+    }
+
+    /**
+     * Validate input data for creating/updating a processing activity.
+     *
+     * @param  array<string, mixed>  $data
+     *
+     * @throws ValidationException
+     */
+    protected function validateInput( array $data, bool $isUpdate = false ): void
+    {
+        $rules = [
+            'name'                => $isUpdate ? 'sometimes|required|string|min:1|max:255' : 'required|string|min:1|max:255',
+            'description'         => 'nullable|string|max:65535',
+            'controller_name'     => 'nullable|string|max:255',
+            'controller_contact'  => 'nullable|string|max:255',
+            'processor_name'      => 'nullable|string|max:255',
+            'processor_contact'   => 'nullable|string|max:255',
+            'dpo_contact'         => 'nullable|string|max:255',
+            'purposes'            => 'nullable|array',
+            'legal_bases'         => 'nullable|array',
+            'data_categories'     => 'nullable|array',
+            'data_subjects'       => 'nullable|array',
+            'recipients'          => 'nullable|array',
+            'third_countries'     => 'nullable|array',
+            'safeguards'          => 'nullable|array',
+            'retention_policy'    => 'nullable|array',
+            'security_measures'   => 'nullable|array',
+            'automated_decisions' => 'nullable|array',
+            'next_review_at'      => 'nullable|date',
+            'status'              => 'nullable|string|in:' . implode( ',', $this->validStatuses ),
+        ];
+
+        $validator = Validator::make( $data, $rules );
+
+        if ( $validator->fails() ) {
+            throw new ValidationException( $validator );
+        }
+    }
+
+    /**
+     * Sanitize and normalize input data.
+     *
+     * @param  array<string, mixed>  $data
+     *
+     * @return array<string, mixed>
+     */
+    protected function sanitizeData( array $data ): array
+    {
+        // Ensure all array fields are arrays
+        foreach ( $this->arrayFields as $field ) {
+            if ( isset( $data[ $field ] ) ) {
+                $data[ $field ] = is_array( $data[ $field ] ) ? $data[ $field ] : [];
+            } else {
+                $data[ $field ] = [];
+            }
+        }
+
+        // Normalize next_review_at date
+        if ( isset( $data['next_review_at'] ) && is_string( $data['next_review_at'] ) ) {
+            $data['next_review_at'] = \Carbon\Carbon::parse( $data['next_review_at'] );
+        }
+
+        return $data;
+    }
+
+    /**
+     * Determine if DPIA is required.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    protected function determineDpiaRequired( array $data ): bool
+    {
+        // Check for special categories - ensure config value is an array
+        $specialCategories = config( 'artisanpack.compliance.compliance.special_categories' );
+        $specialCategories = is_array( $specialCategories ) ? $specialCategories : [];
+        $dataCategories    = $data['data_categories'] ?? [];
+        $dataCategories    = is_array( $dataCategories ) ? $dataCategories : [];
+
+        if ( ! empty( array_intersect( $dataCategories, $specialCategories ) ) ) {
+            return true;
+        }
+
+        // Check for automated decision making with legal effects
+        if ( ! empty( $data['automated_decisions'] ) ) {
+            return true;
+        }
+
+        // Check for large scale monitoring
+        $purposes = $data['purposes'] ?? [];
+        $purposes = is_array( $purposes ) ? $purposes : [];
+        if ( in_array( 'systematic_monitoring', $purposes ) ) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Compliance/Assessment/ProcessingActivityService.php
+++ b/src/Compliance/Assessment/ProcessingActivityService.php
@@ -177,7 +177,7 @@ class ProcessingActivityService
             'generated_at' => now()->toIso8601String(),
             'organization' => [
                 'name'        => config( 'app.name' ),
-                'dpo_contact' => config( 'artisanpack.compliance.compliance.dpia.dpo_contact' ),
+                'dpo_contact' => config( 'artisanpack.compliance.dpia.dpo_contact' ),
             ],
             'activities' => $activities->map( function ( ProcessingActivity $activity ) {
                 return [
@@ -297,7 +297,7 @@ class ProcessingActivityService
     protected function determineDpiaRequired( array $data ): bool
     {
         // Check for special categories - ensure config value is an array
-        $specialCategories = config( 'artisanpack.compliance.compliance.special_categories' );
+        $specialCategories = config( 'artisanpack.compliance.special_categories' );
         $specialCategories = is_array( $specialCategories ) ? $specialCategories : [];
         $dataCategories    = $data['data_categories'] ?? [];
         $dataCategories    = is_array( $dataCategories ) ? $dataCategories : [];

--- a/src/Compliance/Assessment/RiskCalculator.php
+++ b/src/Compliance/Assessment/RiskCalculator.php
@@ -64,7 +64,7 @@ class RiskCalculator
         }
 
         // Use highest risk or average based on methodology
-        $method = config( 'artisanpack.compliance.compliance.dpia.risk_calculation_method', 'highest' );
+        $method = config( 'artisanpack.compliance.dpia.risk_calculation_method', 'highest' );
 
         $score = match ( $method ) {
             'highest'  => $risks->max( 'inherent_score' ),
@@ -139,7 +139,7 @@ class RiskCalculator
      */
     public function suggestRiskLevel( string $riskCategory, array $dataCategories ): string
     {
-        $specialCategories = config( 'artisanpack.compliance.compliance.special_categories', [] );
+        $specialCategories = config( 'artisanpack.compliance.special_categories', [] );
 
         $hasSpecialCategory = ! empty( array_intersect( $dataCategories, $specialCategories ) );
 

--- a/src/Compliance/Assessment/RiskCalculator.php
+++ b/src/Compliance/Assessment/RiskCalculator.php
@@ -1,0 +1,238 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Assessment;
+
+use ArtisanPackUI\Compliance\Models\AssessmentRisk;
+use Illuminate\Support\Collection;
+
+class RiskCalculator
+{
+    /**
+     * Likelihood values and their numeric scores.
+     * Mirrors AssessmentRisk::LIKELIHOOD_SCORES for matrix calculations.
+     *
+     * @var array<string, int>
+     */
+    protected const LIKELIHOOD_SCORES = [
+        'rare'           => 1,
+        'unlikely'       => 2,
+        'possible'       => 3,
+        'likely'         => 4,
+        'almost_certain' => 5,
+    ];
+
+    /**
+     * Impact values and their numeric scores.
+     * Mirrors AssessmentRisk::IMPACT_SCORES for matrix calculations.
+     *
+     * @var array<string, int>
+     */
+    protected const IMPACT_SCORES = [
+        'negligible' => 1,
+        'minor'      => 2,
+        'moderate'   => 3,
+        'major'      => 4,
+        'severe'     => 5,
+    ];
+
+    /**
+     * Risk level thresholds using inclusive lower bounds and exclusive upper bounds.
+     * Ranges are contiguous: low [0, 4), medium [4, 9), high [9, 16), critical [16, 25]
+     *
+     * @var array<string, array{min: float, max: float}>
+     */
+    protected array $thresholds = [
+        'low'      => ['min' => 0, 'max' => 4],
+        'medium'   => ['min' => 4, 'max' => 9],
+        'high'     => ['min' => 9, 'max' => 16],
+        'critical' => ['min' => 16, 'max' => 25],
+    ];
+
+    /**
+     * Calculate overall risk for a collection of risks.
+     *
+     * @param  Collection<int, AssessmentRisk>  $risks
+     *
+     * @return array{score: float, level: string}
+     */
+    public function calculateOverallRisk( Collection $risks ): array
+    {
+        if ( $risks->isEmpty() ) {
+            return ['score' => 0, 'level' => 'low'];
+        }
+
+        // Use highest risk or average based on methodology
+        $method = config( 'artisanpack.compliance.compliance.dpia.risk_calculation_method', 'highest' );
+
+        $score = match ( $method ) {
+            'highest'  => $risks->max( 'inherent_score' ),
+            'average'  => $risks->avg( 'inherent_score' ),
+            'weighted' => $this->calculateWeightedRisk( $risks ),
+            default    => $risks->max( 'inherent_score' ),
+        };
+
+        return [
+            'score' => round( $score, 2 ),
+            'level' => $this->determineLevel( $score ),
+        ];
+    }
+
+    /**
+     * Calculate residual risk after mitigations.
+     */
+    public function calculateResidualRisk( AssessmentRisk $risk ): float
+    {
+        $mitigations = $risk->mitigations()->where( 'status', 'implemented' )->get();
+
+        if ( $mitigations->isEmpty() ) {
+            return $risk->inherent_score;
+        }
+
+        $effectivenessTotal   = $mitigations->sum( 'effectiveness_rating' );
+        $averageEffectiveness = $effectivenessTotal / $mitigations->count();
+
+        // Reduce inherent risk based on mitigation effectiveness (0-100%)
+        $reduction = ( $averageEffectiveness / 100 ) * $risk->inherent_score;
+
+        return max( 1, $risk->inherent_score - $reduction );
+    }
+
+    /**
+     * Determine risk level from score.
+     *
+     * Uses inclusive lower bound and exclusive upper bound for all levels
+     * except critical which uses inclusive upper bound.
+     */
+    public function determineLevel( float $score ): string
+    {
+        // Handle edge cases
+        if ( $score < 0 ) {
+            return 'low';
+        }
+
+        if ( $score >= 25 ) {
+            return 'critical';
+        }
+
+        // Use >= min and < max for contiguous ranges (except critical which is <= max)
+        foreach ( $this->thresholds as $level => $range ) {
+            if ( 'critical' === $level ) {
+                if ( $score >= $range['min'] && $score <= $range['max'] ) {
+                    return $level;
+                }
+            } else {
+                if ( $score >= $range['min'] && $score < $range['max'] ) {
+                    return $level;
+                }
+            }
+        }
+
+        return 'critical';
+    }
+
+    /**
+     * Suggest risk level based on category and data types.
+     *
+     * @param  array<string>  $dataCategories
+     */
+    public function suggestRiskLevel( string $riskCategory, array $dataCategories ): string
+    {
+        $specialCategories = config( 'artisanpack.compliance.compliance.special_categories', [] );
+
+        $hasSpecialCategory = ! empty( array_intersect( $dataCategories, $specialCategories ) );
+
+        $baseLevels = [
+            'data_breach'         => $hasSpecialCategory ? 'critical' : 'high',
+            'unauthorized_access' => $hasSpecialCategory ? 'high' : 'medium',
+            'data_loss'           => $hasSpecialCategory ? 'high' : 'medium',
+            'non_compliance'      => 'high',
+            'reputational'        => 'medium',
+            'operational'         => 'low',
+        ];
+
+        return $baseLevels[ $riskCategory ] ?? 'medium';
+    }
+
+    /**
+     * Get risk matrix data for visualization.
+     *
+     * @return array<string, array<string, string>>
+     */
+    public function getRiskMatrix(): array
+    {
+        $likelihoods = array_keys( self::LIKELIHOOD_SCORES );
+        $impacts     = array_keys( self::IMPACT_SCORES );
+
+        $matrix = [];
+        foreach ( $likelihoods as $likelihood ) {
+            foreach ( $impacts as $impact ) {
+                $likelihoodScore                  = self::LIKELIHOOD_SCORES[ $likelihood ];
+                $impactScore                      = self::IMPACT_SCORES[ $impact ];
+                $score                            = $likelihoodScore * $impactScore;
+                $matrix[ $likelihood ][ $impact ] = $this->determineLevel( $score );
+            }
+        }
+
+        return $matrix;
+    }
+
+    /**
+     * Get recommended mitigations based on risk category.
+     *
+     * @return array<array{title: string, type: string, description: string}>
+     */
+    public function getRecommendedMitigations( string $riskCategory ): array
+    {
+        $recommendations = [
+            'data_breach' => [
+                ['title' => 'Implement encryption', 'type' => 'technical', 'description' => 'Encrypt data at rest and in transit'],
+                ['title' => 'Access controls', 'type' => 'technical', 'description' => 'Implement role-based access control'],
+                ['title' => 'Incident response plan', 'type' => 'organizational', 'description' => 'Document and test incident response procedures'],
+            ],
+            'unauthorized_access' => [
+                ['title' => 'Multi-factor authentication', 'type' => 'technical', 'description' => 'Require MFA for sensitive operations'],
+                ['title' => 'Access logging', 'type' => 'technical', 'description' => 'Implement comprehensive access logging'],
+                ['title' => 'Regular access reviews', 'type' => 'organizational', 'description' => 'Periodically review and revoke unnecessary access'],
+            ],
+            'data_loss' => [
+                ['title' => 'Backup procedures', 'type' => 'technical', 'description' => 'Implement regular encrypted backups'],
+                ['title' => 'Disaster recovery', 'type' => 'organizational', 'description' => 'Document and test disaster recovery procedures'],
+            ],
+            'non_compliance' => [
+                ['title' => 'Compliance training', 'type' => 'organizational', 'description' => 'Regular staff training on data protection'],
+                ['title' => 'Data processing agreements', 'type' => 'contractual', 'description' => 'Ensure DPAs with all processors'],
+                ['title' => 'Regular audits', 'type' => 'organizational', 'description' => 'Conduct periodic compliance audits'],
+            ],
+        ];
+
+        return $recommendations[ $riskCategory ] ?? [];
+    }
+
+    /**
+     * Calculate weighted risk score.
+     *
+     * @param  Collection<int, AssessmentRisk>  $risks
+     */
+    protected function calculateWeightedRisk( Collection $risks ): float
+    {
+        $weights = [
+            'critical' => 4,
+            'high'     => 3,
+            'medium'   => 2,
+            'low'      => 1,
+        ];
+
+        $totalWeight = 0;
+        $weightedSum = 0;
+
+        foreach ( $risks as $risk ) {
+            $weight = $weights[ $risk->risk_level ] ?? 1;
+            $weightedSum += $risk->inherent_score * $weight;
+            $totalWeight += $weight;
+        }
+
+        return $totalWeight > 0 ? $weightedSum / $totalWeight : 0;
+    }
+}

--- a/src/Compliance/Consent/ConsentManager.php
+++ b/src/Compliance/Consent/ConsentManager.php
@@ -43,6 +43,18 @@ class ConsentManager
                     'withdrawn_at'      => now(),
                     'withdrawal_reason' => 'Superseded by new consent',
                 ] );
+
+                // Record the implicit withdrawal in the audit log too —
+                // getHistory() reads from ConsentAuditLog, so without this
+                // the superseded consent's withdrawal disappears from the
+                // compliance trail.
+                $this->logConsentChange(
+                    $existing,
+                    'withdrawn',
+                    'granted',
+                    'withdrawn',
+                    'Superseded by new consent',
+                );
             }
 
             // Create new consent record

--- a/src/Compliance/Consent/ConsentManager.php
+++ b/src/Compliance/Consent/ConsentManager.php
@@ -23,13 +23,21 @@ class ConsentManager
      */
     public function grant( int $userId, string $purpose, array $options = [] ): ConsentRecord
     {
-        $policy = ConsentPolicy::getLatestForPurpose( $purpose );
+        return DB::transaction( function () use ( $userId, $purpose, $options ) {
+            // Read + lock the active policy inside the transaction so a
+            // concurrent updatePolicyVersion() can't flip the active row
+            // between the lookup and the insert. Otherwise we could
+            // record a brand-new consent against an already-superseded
+            // policy version.
+            $policy = ConsentPolicy::where( 'purpose', $purpose )
+                ->where( 'is_active', true )
+                ->lockForUpdate()
+                ->first();
 
-        if ( ! $policy ) {
-            throw new InvalidArgumentException( "No active consent policy found for purpose: {$purpose}" );
-        }
+            if ( ! $policy ) {
+                throw new InvalidArgumentException( "No active consent policy found for purpose: {$purpose}" );
+            }
 
-        return DB::transaction( function () use ( $userId, $purpose, $policy, $options ) {
             // Check for existing consent and withdraw it (use pessimistic locking to prevent race conditions)
             $existing = ConsentRecord::where( 'user_id', $userId )
                 ->where( 'purpose', $purpose )

--- a/src/Compliance/Consent/ConsentManager.php
+++ b/src/Compliance/Consent/ConsentManager.php
@@ -79,9 +79,14 @@ class ConsentManager
     public function withdraw( int $userId, string $purpose, ?string $reason = null ): bool
     {
         return DB::transaction( function () use ( $userId, $purpose, $reason ) {
+            // Pessimistic lock to mirror grant()'s locking. Without this
+            // a concurrent grant() could land between our SELECT and the
+            // UPDATE, leaving the new grant in place while we mark the
+            // stale row as withdrawn.
             $record = ConsentRecord::where( 'user_id', $userId )
                 ->where( 'purpose', $purpose )
                 ->where( 'status', 'granted' )
+                ->lockForUpdate()
                 ->first();
 
             if ( ! $record ) {

--- a/src/Compliance/Consent/ConsentManager.php
+++ b/src/Compliance/Consent/ConsentManager.php
@@ -66,8 +66,12 @@ class ConsentManager
             // Log the consent grant
             $this->logConsentChange( $record, 'granted', null, 'granted' );
 
-            // Fire event
-            event( new ConsentGranted( $record ) );
+            // Defer event dispatch until the transaction commits — listeners
+            // doing external work (sending emails, calling out to a
+            // marketing tool, etc.) shouldn't observe uncommitted state
+            // and shouldn't fire if a later operation rolls the transaction
+            // back.
+            DB::afterCommit( fn () => event( new ConsentGranted( $record ) ) );
 
             return $record;
         } );
@@ -102,8 +106,8 @@ class ConsentManager
             // Log the withdrawal
             $this->logConsentChange( $record, 'withdrawn', 'granted', 'withdrawn', $reason );
 
-            // Fire event
-            event( new ConsentWithdrawn( $record ) );
+            // Defer event dispatch until commit (see grant() for rationale).
+            DB::afterCommit( fn () => event( new ConsentWithdrawn( $record ) ) );
 
             return true;
         } );
@@ -178,11 +182,20 @@ class ConsentManager
     public function updatePolicyVersion( string $purpose, string $version, array $changes ): ConsentPolicy
     {
         return DB::transaction( function () use ( $purpose, $version, $changes ) {
-            $currentPolicy = ConsentPolicy::getLatestForPurpose( $purpose );
+            // Lock the active policy row for this purpose so two concurrent
+            // updatePolicyVersion calls can't both insert a new active row
+            // (each thinking the other's read returned null or stale data).
+            $currentPolicy = ConsentPolicy::where( 'purpose', $purpose )
+                ->where( 'is_active', true )
+                ->lockForUpdate()
+                ->first();
 
-            // Validate required fields when creating the first policy
+            // Validate required fields when creating the first policy.
+            // The contract says BOTH `name` AND `legal_text` are required —
+            // an `&&` here was wrong (it accepts the policy when only one
+            // field is present).
             if ( null === $currentPolicy ) {
-                if ( empty( $changes['name'] ) && empty( $changes['legal_text'] ) ) {
+                if ( empty( $changes['name'] ) || empty( $changes['legal_text'] ) ) {
                     throw new InvalidArgumentException(
                         'When creating the first policy for a purpose, "name" and "legal_text" are required in the changes array.',
                     );
@@ -298,7 +311,7 @@ class ConsentManager
         // Check if policy has changed
         $currentPolicy = ConsentPolicy::getLatestForPurpose( $purpose );
         if ( $currentPolicy && $record->policy_version !== $currentPolicy->version ) {
-            if ( config( 'artisanpack.compliance.compliance.consent.reconsent_on_policy_change', true ) ) {
+            if ( config( 'artisanpack.compliance.consent.reconsent_on_policy_change', true ) ) {
                 return ConsentVerification::reconsentRequired( $record, 'Policy has been updated' );
             }
         }
@@ -357,7 +370,7 @@ class ConsentManager
         // expiration); fall back to the global default. A null on both
         // sides means consent never expires.
         $expiryDays = $policy->retention_period
-            ?? config( 'artisanpack.compliance.compliance.consent.default_expiry_days' );
+            ?? config( 'artisanpack.compliance.consent.default_expiry_days' );
 
         if ( null === $expiryDays ) {
             return null;

--- a/src/Compliance/Consent/ConsentManager.php
+++ b/src/Compliance/Consent/ConsentManager.php
@@ -80,6 +80,7 @@ class ConsentManager
                 'user_agent'         => $options['user_agent'] ?? request()->userAgent(),
                 'proof_reference'    => $options['proof_reference'] ?? null,
                 'granular_choices'   => $options['granular_choices'] ?? null,
+                'granted_at'         => now(),
                 'expires_at'         => $this->calculateExpiration( $policy ),
                 'metadata'           => $options['metadata'] ?? null,
             ] );

--- a/src/Compliance/Consent/ConsentManager.php
+++ b/src/Compliance/Consent/ConsentManager.php
@@ -1,0 +1,389 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Consent;
+
+use ArtisanPackUI\Compliance\Events\ConsentGranted;
+use ArtisanPackUI\Compliance\Events\ConsentWithdrawn;
+use ArtisanPackUI\Compliance\Models\ConsentAuditLog;
+use ArtisanPackUI\Compliance\Models\ConsentPolicy;
+use ArtisanPackUI\Compliance\Models\ConsentRecord;
+use DateTime;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+
+class ConsentManager
+{
+    /**
+     * Record a consent grant.
+     *
+     * @param  array<string, mixed>  $options
+     */
+    public function grant( int $userId, string $purpose, array $options = [] ): ConsentRecord
+    {
+        $policy = ConsentPolicy::getLatestForPurpose( $purpose );
+
+        if ( ! $policy ) {
+            throw new InvalidArgumentException( "No active consent policy found for purpose: {$purpose}" );
+        }
+
+        return DB::transaction( function () use ( $userId, $purpose, $policy, $options ) {
+            // Check for existing consent and withdraw it (use pessimistic locking to prevent race conditions)
+            $existing = ConsentRecord::where( 'user_id', $userId )
+                ->where( 'purpose', $purpose )
+                ->where( 'status', 'granted' )
+                ->lockForUpdate()
+                ->first();
+
+            if ( $existing ) {
+                $existing->update( [
+                    'status'            => 'withdrawn',
+                    'withdrawn_at'      => now(),
+                    'withdrawal_reason' => 'Superseded by new consent',
+                ] );
+            }
+
+            // Create new consent record
+            $record = ConsentRecord::create( [
+                'user_id'            => $userId,
+                'purpose'            => $purpose,
+                'policy_id'          => $policy->id,
+                'policy_version'     => $policy->version,
+                'status'             => 'granted',
+                'consent_type'       => $options['consent_type'] ?? ( $policy->requires_explicit ? 'explicit' : 'implied' ),
+                'collection_method'  => $options['collection_method'] ?? 'web_form',
+                'collection_context' => $options['collection_context'] ?? null,
+                'ip_address'         => $options['ip_address'] ?? request()->ip(),
+                'user_agent'         => $options['user_agent'] ?? request()->userAgent(),
+                'proof_reference'    => $options['proof_reference'] ?? null,
+                'granular_choices'   => $options['granular_choices'] ?? null,
+                'expires_at'         => $this->calculateExpiration( $policy ),
+                'metadata'           => $options['metadata'] ?? null,
+            ] );
+
+            // Log the consent grant
+            $this->logConsentChange( $record, 'granted', null, 'granted' );
+
+            // Fire event
+            event( new ConsentGranted( $record ) );
+
+            return $record;
+        } );
+    }
+
+    /**
+     * Withdraw consent.
+     */
+    public function withdraw( int $userId, string $purpose, ?string $reason = null ): bool
+    {
+        return DB::transaction( function () use ( $userId, $purpose, $reason ) {
+            $record = ConsentRecord::where( 'user_id', $userId )
+                ->where( 'purpose', $purpose )
+                ->where( 'status', 'granted' )
+                ->first();
+
+            if ( ! $record ) {
+                return false;
+            }
+
+            $record->update( [
+                'status'            => 'withdrawn',
+                'withdrawn_at'      => now(),
+                'withdrawal_reason' => $reason,
+            ] );
+
+            // Log the withdrawal
+            $this->logConsentChange( $record, 'withdrawn', 'granted', 'withdrawn', $reason );
+
+            // Fire event
+            event( new ConsentWithdrawn( $record ) );
+
+            return true;
+        } );
+    }
+
+    /**
+     * Check if consent is valid for purpose.
+     */
+    public function hasConsent( int $userId, string $purpose ): bool
+    {
+        return ConsentRecord::where( 'user_id', $userId )
+            ->where( 'purpose', $purpose )
+            ->valid()
+            ->exists();
+    }
+
+    /**
+     * Get all consents for user.
+     */
+    public function getConsents( int $userId ): Collection
+    {
+        return ConsentRecord::where( 'user_id', $userId )
+            ->with( 'policy' )
+            ->orderByDesc( 'created_at' )
+            ->get();
+    }
+
+    /**
+     * Get consent status for multiple purposes.
+     *
+     * @param  array<string>  $purposes
+     *
+     * @return array<string, bool>
+     */
+    public function getConsentStatus( int $userId, array $purposes ): array
+    {
+        $granted = ConsentRecord::where( 'user_id', $userId )
+            ->whereIn( 'purpose', $purposes )
+            ->valid()
+            ->pluck( 'purpose' )
+            ->toArray();
+
+        $status = [];
+        foreach ( $purposes as $purpose ) {
+            $status[ $purpose ] = in_array( $purpose, $granted );
+        }
+
+        return $status;
+    }
+
+    /**
+     * Get consent history for user.
+     */
+    public function getHistory( int $userId, ?string $purpose = null ): Collection
+    {
+        $query = ConsentAuditLog::where( 'user_id', $userId );
+
+        if ( $purpose ) {
+            $query->where( 'purpose', $purpose );
+        }
+
+        return $query->orderByDesc( 'created_at' )->get();
+    }
+
+    /**
+     * Update consent policy version.
+     *
+     * @param  array<string, mixed>  $changes
+     *
+     * @throws InvalidArgumentException When creating first policy without required fields
+     */
+    public function updatePolicyVersion( string $purpose, string $version, array $changes ): ConsentPolicy
+    {
+        return DB::transaction( function () use ( $purpose, $version, $changes ) {
+            $currentPolicy = ConsentPolicy::getLatestForPurpose( $purpose );
+
+            // Validate required fields when creating the first policy
+            if ( null === $currentPolicy ) {
+                if ( empty( $changes['name'] ) && empty( $changes['legal_text'] ) ) {
+                    throw new InvalidArgumentException(
+                        'When creating the first policy for a purpose, "name" and "legal_text" are required in the changes array.',
+                    );
+                }
+            }
+
+            $newPolicy = ConsentPolicy::create( [
+                'purpose'                 => $purpose,
+                'name'                    => $changes['name'] ?? $currentPolicy?->name ?? ucfirst( $purpose ),
+                'description'             => $changes['description'] ?? $currentPolicy?->description,
+                'legal_text'              => $changes['legal_text'] ?? $currentPolicy?->legal_text ?? '',
+                'version'                 => $version,
+                'previous_version_id'     => $currentPolicy?->id ?? null,
+                'data_categories'         => $changes['data_categories'] ?? $currentPolicy?->data_categories,
+                'processing_details'      => $changes['processing_details'] ?? $currentPolicy?->processing_details,
+                'retention_period'        => $changes['retention_period'] ?? $currentPolicy?->retention_period,
+                'third_party_sharing'     => $changes['third_party_sharing'] ?? $currentPolicy?->third_party_sharing,
+                'rights_description'      => $changes['rights_description'] ?? $currentPolicy?->rights_description,
+                'withdrawal_consequences' => $changes['withdrawal_consequences'] ?? $currentPolicy?->withdrawal_consequences,
+                'is_required'             => $changes['is_required'] ?? $currentPolicy?->is_required ?? false,
+                'is_active'               => true,
+                'requires_explicit'       => $changes['requires_explicit'] ?? $currentPolicy?->requires_explicit ?? true,
+                'minimum_age'             => $changes['minimum_age'] ?? $currentPolicy?->minimum_age ?? 16,
+                'effective_at'            => $changes['effective_at'] ?? now(),
+                'expires_at'              => $changes['expires_at'] ?? null,
+                'changes_from_previous'   => $changes,
+                'created_by'              => auth()->id(),
+            ] );
+
+            // Deactivate old policy
+            if ( $currentPolicy ) {
+                $currentPolicy->update( ['is_active' => false] );
+            }
+
+            return $newPolicy;
+        } );
+    }
+
+    /**
+     * Get users who need to reconsent.
+     */
+    public function getUsersRequiringReconsent( string $purpose ): Collection
+    {
+        $currentPolicy = ConsentPolicy::getLatestForPurpose( $purpose );
+
+        if ( ! $currentPolicy ) {
+            return collect();
+        }
+
+        return ConsentRecord::where( 'purpose', $purpose )
+            ->where( 'status', 'granted' )
+            ->where( 'policy_version', '!=', $currentPolicy->version )
+            ->get();
+    }
+
+    /**
+     * Send reconsent notifications.
+     */
+    public function notifyReconsent( string $purpose ): int
+    {
+        $records = $this->getUsersRequiringReconsent( $purpose );
+        $count   = 0;
+
+        foreach ( $records as $record ) {
+            // TODO: Send notification to user
+            $count++;
+        }
+
+        return $count;
+    }
+
+    /**
+     * Export consent records for user.
+     *
+     * @return array<string, mixed>
+     */
+    public function exportConsents( int $userId ): array
+    {
+        $records = $this->getConsents( $userId );
+
+        return $records->map( function ( ConsentRecord $record ) {
+            return [
+                'purpose'          => $record->purpose,
+                'policy_version'   => $record->policy_version,
+                'status'           => $record->status,
+                'consent_type'     => $record->consent_type,
+                'granted_at'       => $record->created_at->toIso8601String(),
+                'withdrawn_at'     => $record->withdrawn_at?->toIso8601String(),
+                'expires_at'       => $record->expires_at?->toIso8601String(),
+                'granular_choices' => $record->granular_choices,
+            ];
+        } )->toArray();
+    }
+
+    /**
+     * Verify consent is valid (not expired, policy not changed).
+     */
+    public function verifyConsent( int $userId, string $purpose ): ConsentVerification
+    {
+        $record = ConsentRecord::where( 'user_id', $userId )
+            ->where( 'purpose', $purpose )
+            ->where( 'status', 'granted' )
+            ->first();
+
+        if ( ! $record ) {
+            return ConsentVerification::invalid( 'No consent record found' );
+        }
+
+        if ( $record->isExpired() ) {
+            return ConsentVerification::invalid( 'Consent has expired', true );
+        }
+
+        // Check if policy has changed
+        $currentPolicy = ConsentPolicy::getLatestForPurpose( $purpose );
+        if ( $currentPolicy && $record->policy_version !== $currentPolicy->version ) {
+            if ( config( 'artisanpack.compliance.compliance.consent.reconsent_on_policy_change', true ) ) {
+                return ConsentVerification::reconsentRequired( $record, 'Policy has been updated' );
+            }
+        }
+
+        return ConsentVerification::valid( $record );
+    }
+
+    /**
+     * Get consent statistics.
+     *
+     * @return array<string, mixed>
+     */
+    public function getStatistics( ?string $purpose = null ): array
+    {
+        $query = ConsentRecord::query();
+
+        if ( $purpose ) {
+            $query->where( 'purpose', $purpose );
+        }
+
+        $total     = $query->count();
+        $granted   = ( clone $query )->where( 'status', 'granted' )->count();
+        $withdrawn = ( clone $query )->where( 'status', 'withdrawn' )->count();
+        $expired   = ( clone $query )->where( 'status', 'expired' )->count();
+
+        $byPurposeQuery = ConsentRecord::selectRaw( 'purpose, status, count(*) as count' );
+
+        if ( $purpose ) {
+            $byPurposeQuery->where( 'purpose', $purpose );
+        }
+
+        $byPurpose = $byPurposeQuery
+            ->groupBy( 'purpose', 'status' )
+            ->get()
+            ->groupBy( 'purpose' )
+            ->map( function ( $items ) {
+                return $items->pluck( 'count', 'status' );
+            } );
+
+        return [
+            'total'      => $total,
+            'granted'    => $granted,
+            'withdrawn'  => $withdrawn,
+            'expired'    => $expired,
+            'grant_rate' => $total > 0 ? round( ( $granted / $total ) * 100, 2 ) : 0,
+            'by_purpose' => $byPurpose,
+        ];
+    }
+
+    /**
+     * Calculate consent expiration date.
+     */
+    protected function calculateExpiration( ConsentPolicy $policy ): ?DateTime
+    {
+        // Prefer the policy's own retention_period (per-purpose
+        // expiration); fall back to the global default. A null on both
+        // sides means consent never expires.
+        $expiryDays = $policy->retention_period
+            ?? config( 'artisanpack.compliance.compliance.consent.default_expiry_days' );
+
+        if ( null === $expiryDays ) {
+            return null;
+        }
+
+        return now()->addDays( (int) $expiryDays );
+    }
+
+    /**
+     * Log a consent change.
+     */
+    protected function logConsentChange(
+        ConsentRecord $record,
+        string $action,
+        ?string $oldStatus,
+        ?string $newStatus,
+        ?string $reason = null,
+    ): void {
+        ConsentAuditLog::create( [
+            'consent_record_id' => $record->id,
+            'user_id'           => $record->user_id,
+            'action'            => $action,
+            'purpose'           => $record->purpose,
+            'old_status'        => $oldStatus,
+            'new_status'        => $newStatus,
+            'policy_version'    => $record->policy_version,
+            'actor_type'        => auth()->check() ? 'user' : 'system',
+            'actor_id'          => auth()->id(),
+            'reason'            => $reason,
+            'ip_address'        => request()->ip(),
+            'user_agent'        => request()->userAgent(),
+        ]);
+    }
+}

--- a/src/Compliance/Consent/ConsentManager.php
+++ b/src/Compliance/Consent/ConsentManager.php
@@ -13,6 +13,7 @@ use DateTime;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
+use LogicException;
 
 class ConsentManager
 {
@@ -273,18 +274,26 @@ class ConsentManager
 
     /**
      * Send reconsent notifications.
+     *
+     * Override this method (or replace the trait via a custom
+     * ConsentManager subclass / container binding) to wire in your
+     * app's notification channel — the package ships without one
+     * because reconsent UX is highly app-specific.
+     *
+     * @throws LogicException Always — calling the unimplemented base
+     *   method would otherwise return a sent-count for notifications
+     *   that never actually left the system.
      */
     public function notifyReconsent( string $purpose ): int
     {
-        $records = $this->getUsersRequiringReconsent( $purpose );
-        $count   = 0;
-
-        foreach ( $records as $record ) {
-            // TODO: Send notification to user
-            $count++;
-        }
-
-        return $count;
+        throw new LogicException(
+            sprintf(
+                'ConsentManager::notifyReconsent() is unimplemented in the base package. '
+                    . 'Override it (or bind a subclass) to dispatch a notification per record from '
+                    . 'getUsersRequiringReconsent(\'%s\').',
+                $purpose,
+            ),
+        );
     }
 
     /**

--- a/src/Compliance/Consent/ConsentPolicyService.php
+++ b/src/Compliance/Consent/ConsentPolicyService.php
@@ -1,0 +1,278 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Consent;
+
+use ArtisanPackUI\Compliance\Models\ConsentPolicy;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+
+class ConsentPolicyService
+{
+    /**
+     * Internal keys that should not be stored in changes_from_previous.
+     *
+     * @var array<string>
+     */
+    protected array $internalChangeKeys = [
+        'version',
+        'previous_version_id',
+        'is_active',
+        'created_by',
+        'changes_from_previous',
+    ];
+
+    /**
+     * Create a new consent policy.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function create( array $data ): ConsentPolicy
+    {
+        // Get creator ID - allow null for system/unauthenticated contexts
+        // The created_by column should be nullable in the database
+        $creatorId = $data['created_by'] ?? ( auth()->check() ? auth()->id() : null );
+
+        return ConsentPolicy::create( [
+            'purpose'                 => $data['purpose'],
+            'name'                    => $data['name'],
+            'description'             => $data['description'] ?? null,
+            'legal_text'              => $data['legal_text'],
+            'version'                 => $data['version'] ?? '1.0',
+            'previous_version_id'     => $data['previous_version_id'] ?? null,
+            'data_categories'         => $data['data_categories'] ?? [],
+            'processing_details'      => $data['processing_details'] ?? [],
+            'retention_period'        => $data['retention_period'] ?? null,
+            'third_party_sharing'     => $data['third_party_sharing'] ?? [],
+            'rights_description'      => $data['rights_description'] ?? null,
+            'withdrawal_consequences' => $data['withdrawal_consequences'] ?? null,
+            'is_required'             => $data['is_required'] ?? false,
+            'is_active'               => $data['is_active'] ?? true,
+            'requires_explicit'       => $data['requires_explicit'] ?? true,
+            'minimum_age'             => $data['minimum_age'] ?? 16,
+            'effective_at'            => $data['effective_at'] ?? now(),
+            'expires_at'              => $data['expires_at'] ?? null,
+            'changes_from_previous'   => $data['changes_from_previous'] ?? null,
+            'created_by'              => $creatorId,
+        ] );
+    }
+
+    /**
+     * Update policy (creates new version).
+     *
+     * @param  array<string, mixed>  $changes
+     */
+    public function update( ConsentPolicy $policy, array $changes ): ConsentPolicy
+    {
+        return DB::transaction( function () use ( $policy, $changes ) {
+            // Determine new version with robust parsing
+            $newVersion = $this->incrementVersion( $changes['version'] ?? $policy->version );
+
+            // Filter internal keys from changes for audit trail
+            $auditableChanges = $this->filterInternalKeys( $changes );
+
+            // Deactivate old policy
+            $policy->update( ['is_active' => false] );
+
+            // Create new version
+            return $this->create( array_merge( [
+                'purpose'                 => $policy->purpose,
+                'name'                    => $policy->name,
+                'description'             => $policy->description,
+                'legal_text'              => $policy->legal_text,
+                'data_categories'         => $policy->data_categories,
+                'processing_details'      => $policy->processing_details,
+                'retention_period'        => $policy->retention_period,
+                'third_party_sharing'     => $policy->third_party_sharing,
+                'rights_description'      => $policy->rights_description,
+                'withdrawal_consequences' => $policy->withdrawal_consequences,
+                'is_required'             => $policy->is_required,
+                'requires_explicit'       => $policy->requires_explicit,
+                'minimum_age'             => $policy->minimum_age,
+            ], $changes, [
+                'version'               => $changes['version'] ?? $newVersion,
+                'previous_version_id'   => $policy->id,
+                'changes_from_previous' => $auditableChanges,
+                'is_active'             => true,
+            ] ) );
+        } );
+    }
+
+    /**
+     * Get active policy for purpose.
+     */
+    public function getActive( string $purpose ): ?ConsentPolicy
+    {
+        return ConsentPolicy::getLatestForPurpose( $purpose );
+    }
+
+    /**
+     * Get all versions of a policy, sorted by semantic version (descending).
+     */
+    public function getVersions( string $purpose ): Collection
+    {
+        return ConsentPolicy::where( 'purpose', $purpose )
+            ->get()
+            ->sort( function ( ConsentPolicy $a, ConsentPolicy $b ) {
+                // Use version_compare for proper semantic versioning
+                return version_compare( $b->version, $a->version );
+            } )
+            ->values();
+    }
+
+    /**
+     * Compare two policy versions.
+     *
+     * @return array<string, mixed>
+     */
+    public function compare( ConsentPolicy $v1, ConsentPolicy $v2 ): array
+    {
+        $fields = [
+            'legal_text',
+            'data_categories',
+            'processing_details',
+            'retention_period',
+            'third_party_sharing',
+            'rights_description',
+            'withdrawal_consequences',
+            'is_required',
+            'requires_explicit',
+            'minimum_age',
+        ];
+
+        $differences = [];
+
+        foreach ( $fields as $field ) {
+            if ( $v1->$field !== $v2->$field ) {
+                $differences[ $field ] = [
+                    'old' => $v1->$field,
+                    'new' => $v2->$field,
+                ];
+            }
+        }
+
+        return [
+            'version_1'          => $v1->version,
+            'version_2'          => $v2->version,
+            'differences'        => $differences,
+            'requires_reconsent' => $this->requiresReconsent( $v1, $v2 ),
+        ];
+    }
+
+    /**
+     * Check if policy change requires reconsent.
+     */
+    public function requiresReconsent( ConsentPolicy $oldPolicy, ConsentPolicy $newPolicy ): bool
+    {
+        // Material changes that require reconsent
+        $materialFields = [
+            'data_categories',
+            'processing_details',
+            'third_party_sharing',
+            'retention_period',
+        ];
+
+        foreach ( $materialFields as $field ) {
+            if ( $oldPolicy->$field !== $newPolicy->$field ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Deactivate a policy.
+     */
+    public function deactivate( ConsentPolicy $policy ): void
+    {
+        $policy->update( ['is_active' => false] );
+    }
+
+    /**
+     * Get policies requiring user consent.
+     */
+    public function getRequiredPolicies(): Collection
+    {
+        return ConsentPolicy::active()
+            ->effective()
+            ->where( 'is_required', true )
+            ->get();
+    }
+
+    /**
+     * Get all active policies.
+     */
+    public function getAllActive(): Collection
+    {
+        return ConsentPolicy::active()->effective()->get();
+    }
+
+    /**
+     * Get policies by purpose.
+     *
+     * @param  array<string>  $purposes
+     */
+    public function getByPurposes( array $purposes ): Collection
+    {
+        return ConsentPolicy::active()
+            ->effective()
+            ->whereIn( 'purpose', $purposes )
+            ->get()
+            ->keyBy( 'purpose' );
+    }
+
+    /**
+     * Parse and increment a version string.
+     *
+     * Handles formats like "1.0", "1", "v1.2", "1.2.3" (ignores patch).
+     *
+     * @throws InvalidArgumentException If version cannot be parsed
+     */
+    protected function incrementVersion( string $version ): string
+    {
+        // Normalize: trim whitespace and strip leading 'v' or 'V'
+        $normalized = ltrim( trim( $version ), 'vV' );
+
+        // Handle empty string after normalization
+        if ( '' === $normalized ) {
+            return '1.0';
+        }
+
+        // Split by dots
+        $parts = explode( '.', $normalized );
+
+        // Extract and validate major version
+        $major = $parts[0];
+        if ( ! is_numeric( $major ) ) {
+            throw new InvalidArgumentException(
+                "Cannot parse version '{$version}': major version must be numeric.",
+            );
+        }
+
+        // Extract minor version (default to 0 if missing or non-numeric)
+        $minor = 0;
+        if ( isset( $parts[1] ) && is_numeric( $parts[1] ) ) {
+            $minor = (int) $parts[1];
+        }
+
+        // Increment minor version
+        $minor++;
+
+        return $major . '.' . $minor;
+    }
+
+    /**
+     * Filter internal/metadata keys from changes array.
+     *
+     * @param  array<string, mixed>  $changes
+     *
+     * @return array<string, mixed>
+     */
+    protected function filterInternalKeys( array $changes ): array
+    {
+        return array_diff_key( $changes, array_flip( $this->internalChangeKeys));
+    }
+}

--- a/src/Compliance/Consent/ConsentVerification.php
+++ b/src/Compliance/Consent/ConsentVerification.php
@@ -1,0 +1,57 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Consent;
+
+use ArtisanPackUI\Compliance\Models\ConsentRecord;
+
+class ConsentVerification
+{
+    public function __construct(
+        public readonly bool $isValid,
+        public readonly ?ConsentRecord $record = null,
+        public readonly ?string $reason = null,
+        public readonly bool $requiresReconsent = false,
+        public readonly ?string $policyVersion = null,
+    ) {
+    }
+
+    /**
+     * Create a valid verification result.
+     */
+    public static function valid( ConsentRecord $record ): self
+    {
+        return new self(
+            isValid: true,
+            record: $record,
+            policyVersion: $record->policy_version,
+        );
+    }
+
+    /**
+     * Create an invalid verification result.
+     */
+    public static function invalid( string $reason, bool $requiresReconsent = false ): self
+    {
+        return new self(
+            isValid: false,
+            reason: $reason,
+            requiresReconsent: $requiresReconsent,
+        );
+    }
+
+    /**
+     * Create a result indicating reconsent is required.
+     */
+    public static function reconsentRequired( ConsentRecord $record, string $reason ): self
+    {
+        return new self(
+            isValid: false,
+            record: $record,
+            reason: $reason,
+            requiresReconsent: true,
+            policyVersion: $record->policy_version,
+        );
+    }
+}

--- a/src/Compliance/Consent/CookieConsentHandler.php
+++ b/src/Compliance/Consent/CookieConsentHandler.php
@@ -129,7 +129,7 @@ class CookieConsentHandler
      */
     public function getCategories(): array
     {
-        return config( 'artisanpack.compliance.compliance.consent.cookie_consent.categories', [
+        return config( 'artisanpack.compliance.consent.cookie_consent.categories', [
             'essential',
             'functional',
             'analytics',
@@ -148,7 +148,7 @@ class CookieConsentHandler
             'name'            => self::CONSENT_COOKIE_NAME,
             'lifetime'        => self::CONSENT_COOKIE_LIFETIME,
             'categories'      => $this->getCategories(),
-            'banner_position' => config( 'artisanpack.compliance.compliance.consent.cookie_consent.banner_position', 'bottom' ),
+            'banner_position' => config( 'artisanpack.compliance.consent.cookie_consent.banner_position', 'bottom' ),
         ];
     }
 

--- a/src/Compliance/Consent/CookieConsentHandler.php
+++ b/src/Compliance/Consent/CookieConsentHandler.php
@@ -1,0 +1,182 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Consent;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cookie;
+
+class CookieConsentHandler
+{
+    protected const CONSENT_COOKIE_NAME = 'cookie_consent';
+
+    protected const CONSENT_COOKIE_LIFETIME = 365; // days
+
+    /**
+     * Get the current cookie consent status.
+     *
+     * @return array<string, bool>
+     */
+    public function getConsentStatus( Request $request ): array
+    {
+        $cookie = $request->cookie( self::CONSENT_COOKIE_NAME );
+
+        if ( ! $cookie ) {
+            return $this->getDefaultStatus();
+        }
+
+        $decoded = json_decode( $cookie, true );
+
+        if ( JSON_ERROR_NONE !== json_last_error() || !is_array( $decoded ) ) {
+            return $this->getDefaultStatus();
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * Check if user has given consent for a specific category.
+     */
+    public function hasConsent( Request $request, string $category ): bool
+    {
+        $status = $this->getConsentStatus( $request );
+
+        // Essential cookies are always allowed
+        if ( 'essential' === $category ) {
+            return true;
+        }
+
+        return $status[ $category ] ?? false;
+    }
+
+    /**
+     * Set cookie consent status.
+     *
+     * @param  array<string, bool>  $choices
+     *
+     * @return \Symfony\Component\HttpFoundation\Cookie
+     */
+    public function setConsent( array $choices ): \Symfony\Component\HttpFoundation\Cookie
+    {
+        // Essential is always true
+        $choices['essential'] = true;
+
+        // Throw on encode failure so we never write a `false` value
+        // into a consent cookie — corrupted consent state would be
+        // worse than refusing to set the cookie at all.
+        $value = json_encode( $choices, JSON_THROW_ON_ERROR );
+
+        return Cookie::make(
+            self::CONSENT_COOKIE_NAME,
+            $value,
+            self::CONSENT_COOKIE_LIFETIME * 24 * 60, // convert days to minutes
+            '/',
+            null,
+            true, // secure
+            true, // httpOnly
+            false, // raw
+            'Strict', // sameSite
+        );
+    }
+
+    /**
+     * Accept all cookies.
+     *
+     * @return \Symfony\Component\HttpFoundation\Cookie
+     */
+    public function acceptAll(): \Symfony\Component\HttpFoundation\Cookie
+    {
+        $categories = $this->getCategories();
+        $choices    = [];
+
+        foreach ( $categories as $category ) {
+            $choices[ $category ] = true;
+        }
+
+        return $this->setConsent( $choices );
+    }
+
+    /**
+     * Accept only essential cookies.
+     *
+     * @return \Symfony\Component\HttpFoundation\Cookie
+     */
+    public function acceptEssentialOnly(): \Symfony\Component\HttpFoundation\Cookie
+    {
+        $categories = $this->getCategories();
+        $choices    = [];
+
+        foreach ( $categories as $category ) {
+            $choices[ $category ] = 'essential' === $category;
+        }
+
+        return $this->setConsent( $choices );
+    }
+
+    /**
+     * Check if consent has been given (any choice made).
+     */
+    public function hasConsentBeenGiven( Request $request ): bool
+    {
+        return null !== $request->cookie( self::CONSENT_COOKIE_NAME );
+    }
+
+    /**
+     * Get available cookie categories.
+     *
+     * @return array<string>
+     */
+    public function getCategories(): array
+    {
+        return config( 'artisanpack.compliance.compliance.consent.cookie_consent.categories', [
+            'essential',
+            'functional',
+            'analytics',
+            'marketing',
+        ] );
+    }
+
+    /**
+     * Get the consent cookie configuration.
+     *
+     * @return array<string, mixed>
+     */
+    public function getCookieConfig(): array
+    {
+        return [
+            'name'            => self::CONSENT_COOKIE_NAME,
+            'lifetime'        => self::CONSENT_COOKIE_LIFETIME,
+            'categories'      => $this->getCategories(),
+            'banner_position' => config( 'artisanpack.compliance.compliance.consent.cookie_consent.banner_position', 'bottom' ),
+        ];
+    }
+
+    /**
+     * Clear consent cookie.
+     *
+     * @return \Symfony\Component\HttpFoundation\Cookie
+     */
+    public function clearConsent(): \Symfony\Component\HttpFoundation\Cookie
+    {
+        return Cookie::forget( self::CONSENT_COOKIE_NAME );
+    }
+
+    /**
+     * Get default consent status (no consent given).
+     *
+     * @return array<string, bool>
+     */
+    protected function getDefaultStatus(): array
+    {
+        $categories = $this->getCategories();
+        $status     = [];
+
+        foreach ( $categories as $category ) {
+            // Only essential is true by default
+            $status[ $category ] = 'essential' === $category;
+        }
+
+        return $status;
+    }
+}

--- a/src/Compliance/Contracts/ComplianceCheckInterface.php
+++ b/src/Compliance/Contracts/ComplianceCheckInterface.php
@@ -1,0 +1,57 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Contracts;
+
+use ArtisanPackUI\Compliance\Compliance\Monitoring\CheckResult;
+
+interface ComplianceCheckInterface
+{
+    /**
+     * Get check name.
+     */
+    public function getName(): string;
+
+    /**
+     * Get check description.
+     */
+    public function getDescription(): string;
+
+    /**
+     * Get check category.
+     */
+    public function getCategory(): string;
+
+    /**
+     * Get applicable regulations.
+     *
+     * @return array<string>
+     */
+    public function getRegulations(): array;
+
+    /**
+     * Run the check.
+     */
+    public function run(): CheckResult;
+
+    /**
+     * Check if check is enabled.
+     */
+    public function isEnabled(): bool;
+
+    /**
+     * Get recommended schedule (cron expression).
+     */
+    public function getRecommendedSchedule(): string;
+
+    /**
+     * Get severity of violations found by this check.
+     */
+    public function getSeverity(): string;
+
+    /**
+     * Get remediation guidance.
+     */
+    public function getRemediation(): string;
+}

--- a/src/Compliance/Contracts/ConsentStorageInterface.php
+++ b/src/Compliance/Contracts/ConsentStorageInterface.php
@@ -1,0 +1,50 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Contracts;
+
+use ArtisanPackUI\Compliance\Models\ConsentRecord;
+use Illuminate\Support\Collection;
+
+interface ConsentStorageInterface
+{
+    /**
+     * Store a consent record.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function store( array $data ): ConsentRecord;
+
+    /**
+     * Find consent record by user and purpose.
+     */
+    public function findByUserAndPurpose( int $userId, string $purpose ): ?ConsentRecord;
+
+    /**
+     * Get all consents for a user.
+     */
+    public function getByUser( int $userId ): Collection;
+
+    /**
+     * Update consent record.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function update( ConsentRecord $record, array $data ): ConsentRecord;
+
+    /**
+     * Delete consent record.
+     */
+    public function delete( ConsentRecord $record ): bool;
+
+    /**
+     * Get consent history for user and purpose.
+     */
+    public function getHistory( int $userId, ?string $purpose = null ): Collection;
+
+    /**
+     * Get users with expired consent for purpose.
+     */
+    public function getExpiredConsents( string $purpose ): Collection;
+}

--- a/src/Compliance/Contracts/DataExporterInterface.php
+++ b/src/Compliance/Contracts/DataExporterInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Contracts;
+
+use Illuminate\Support\Collection;
+
+interface DataExporterInterface
+{
+    /**
+     * Get exporter name.
+     */
+    public function getName(): string;
+
+    /**
+     * Get data category.
+     */
+    public function getCategory(): string;
+
+    /**
+     * Get exportable data for user.
+     */
+    public function getData( int $userId ): Collection;
+
+    /**
+     * Get data schema.
+     *
+     * @return array<string, mixed>
+     */
+    public function getSchema(): array;
+
+    /**
+     * Transform data for export.
+     *
+     * @return array<string, mixed>
+     */
+    public function transform( Collection $data ): array;
+
+    /**
+     * Get supported formats.
+     *
+     * @return array<string>
+     */
+    public function getSupportedFormats(): array;
+
+    /**
+     * Get estimated record count.
+     */
+    public function getRecordCount( int $userId ): int;
+}

--- a/src/Compliance/Contracts/ErasureHandlerInterface.php
+++ b/src/Compliance/Contracts/ErasureHandlerInterface.php
@@ -1,0 +1,62 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Contracts;
+
+use ArtisanPackUI\Compliance\Compliance\Erasure\ErasureHandlerResult;
+use Illuminate\Support\Collection;
+
+interface ErasureHandlerInterface
+{
+    /**
+     * Get handler name.
+     */
+    public function getName(): string;
+
+    /**
+     * Get handler description.
+     */
+    public function getDescription(): string;
+
+    /**
+     * Check if handler can process erasure for user.
+     */
+    public function canHandle( int $userId ): bool;
+
+    /**
+     * Find all data for user.
+     */
+    public function findUserData( int $userId ): Collection;
+
+    /**
+     * Execute erasure.
+     *
+     * @param  array<string, mixed>  $options
+     */
+    public function erase( int $userId, array $options = [] ): ErasureHandlerResult;
+
+    /**
+     * Check if erasure is reversible.
+     */
+    public function isReversible(): bool;
+
+    /**
+     * Rollback erasure if possible.
+     *
+     * @param  array<string, mixed>  $backupData
+     */
+    public function rollback( int $userId, array $backupData ): bool;
+
+    /**
+     * Get estimated time to complete in seconds.
+     */
+    public function getEstimatedTime(): int;
+
+    /**
+     * Get data categories handled.
+     *
+     * @return array<string>
+     */
+    public function getDataCategories(): array;
+}

--- a/src/Compliance/Contracts/ReportTypeInterface.php
+++ b/src/Compliance/Contracts/ReportTypeInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Contracts;
+
+use ArtisanPackUI\Compliance\Compliance\Reporting\ComplianceReport;
+
+interface ReportTypeInterface
+{
+    /**
+     * Get report type name.
+     */
+    public function getName(): string;
+
+    /**
+     * Get report type description.
+     */
+    public function getDescription(): string;
+
+    /**
+     * Get report category.
+     */
+    public function getCategory(): string;
+
+    /**
+     * Generate the report.
+     *
+     * @param  array<string, mixed>  $options
+     */
+    public function generate( array $options = [] ): ComplianceReport;
+
+    /**
+     * Get available options for this report.
+     *
+     * @return array<string, mixed>
+     */
+    public function getAvailableOptions(): array;
+
+    /**
+     * Get supported export formats.
+     *
+     * @return array<string>
+     */
+    public function getSupportedFormats(): array;
+
+    /**
+     * Get default schedule for this report type.
+     */
+    public function getDefaultSchedule(): ?string;
+}

--- a/src/Compliance/Erasure/ErasureHandlerResult.php
+++ b/src/Compliance/Erasure/ErasureHandlerResult.php
@@ -1,0 +1,94 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Erasure;
+
+class ErasureHandlerResult
+{
+    /**
+     * @param  array<string, mixed>  $backupData
+     * @param  array<string, mixed>  $retainedRecords
+     */
+    public function __construct(
+        public readonly bool $success,
+        public readonly int $recordsFound = 0,
+        public readonly int $recordsErased = 0,
+        public readonly int $recordsRetained = 0,
+        public readonly ?string $error = null,
+        public readonly array $backupData = [],
+        public readonly array $retainedRecords = [],
+        public readonly ?string $retentionReason = null,
+    ) {
+    }
+
+    /**
+     * Create a successful result.
+     *
+     * @param  array<string, mixed>  $backupData
+     */
+    public static function success( int $found, int $erased, int $retained = 0, array $backupData = [] ): self
+    {
+        return new self(
+            success: true,
+            recordsFound: $found,
+            recordsErased: $erased,
+            recordsRetained: $retained,
+            backupData: $backupData,
+        );
+    }
+
+    /**
+     * Create a failed result.
+     */
+    public static function failed( string $error, int $found = 0 ): self
+    {
+        return new self(
+            success: false,
+            recordsFound: $found,
+            error: $error,
+        );
+    }
+
+    /**
+     * Create a result with retained records.
+     *
+     * @param  array<string, mixed>  $retained
+     */
+    public static function partial( int $found, int $erased, array $retained, string $reason ): self
+    {
+        return new self(
+            success: true,
+            recordsFound: $found,
+            recordsErased: $erased,
+            recordsRetained: count( $retained ),
+            retainedRecords: $retained,
+            retentionReason: $reason,
+        );
+    }
+
+    /**
+     * Check if all records were erased.
+     */
+    public function isComplete(): bool
+    {
+        return $this->success && 0 === $this->recordsRetained;
+    }
+
+    /**
+     * Convert to array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'success'          => $this->success,
+            'records_found'    => $this->recordsFound,
+            'records_erased'   => $this->recordsErased,
+            'records_retained' => $this->recordsRetained,
+            'error'            => $this->error,
+            'retention_reason' => $this->retentionReason,
+        ];
+    }
+}

--- a/src/Compliance/Erasure/ErasureService.php
+++ b/src/Compliance/Erasure/ErasureService.php
@@ -1,0 +1,381 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Erasure;
+
+use ArtisanPackUI\Compliance\Compliance\Contracts\ErasureHandlerInterface;
+use ArtisanPackUI\Compliance\Events\ErasureCompleted;
+use ArtisanPackUI\Compliance\Events\ErasureRequested;
+use ArtisanPackUI\Compliance\Models\ErasureLog;
+use ArtisanPackUI\Compliance\Models\ErasureRequest;
+use Exception;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use JsonException;
+
+class ErasureService
+{
+    /**
+     * @var array<string, ErasureHandlerInterface>
+     */
+    protected array $handlers = [];
+
+    /**
+     * Register an erasure handler.
+     */
+    public function registerHandler( ErasureHandlerInterface $handler ): void
+    {
+        $this->handlers[ $handler->getName() ] = $handler;
+    }
+
+    /**
+     * Get all registered handlers.
+     *
+     * @return array<string, ErasureHandlerInterface>
+     */
+    public function getHandlers(): array
+    {
+        return $this->handlers;
+    }
+
+    /**
+     * Create an erasure request.
+     *
+     * @param  array<string, mixed>  $options
+     */
+    public function createRequest( int $userId, array $options = [] ): ErasureRequest
+    {
+        $request = ErasureRequest::create( [
+            'user_id'           => $userId,
+            'requester_type'    => $options['requester_type'] ?? 'self',
+            'requester_contact' => $options['requester_contact'] ?? null,
+            'status'            => 'pending',
+            'scope'             => $options['scope'] ?? 'full',
+            'specific_data'     => $options['specific_data'] ?? null,
+            'reason'            => $options['reason'] ?? null,
+            'identity_verified' => $options['identity_verified'] ?? false,
+            'created_by'        => auth()->id(),
+        ] );
+
+        event( new ErasureRequested( $request ) );
+
+        return $request;
+    }
+
+    /**
+     * Process an erasure request.
+     */
+    public function processRequest( ErasureRequest $request ): ErasureRequest
+    {
+        return DB::transaction( function () use ( $request ) {
+            $request->update( ['status' => 'processing'] );
+
+            $processedHandlers = [];
+            $failedHandlers    = [];
+            $exemptions        = [];
+
+            foreach ( $this->handlers as $name => $handler ) {
+                // Skip if partial scope and handler not in specific data
+                if ( 'partial' === $request->scope && $request->specific_data ) {
+                    if ( ! in_array( $name, $request->specific_data ) ) {
+                        continue;
+                    }
+                }
+
+                if ( ! $handler->canHandle( $request->user_id ) ) {
+                    continue;
+                }
+
+                $log = $this->createLog( $request, $handler->getName(), 'erase' );
+
+                try {
+                    $result = $handler->erase( $request->user_id, [
+                        'scope'         => $request->scope,
+                        'specific_data' => $request->specific_data,
+                    ] );
+
+                    $log->update( [
+                        'status'           => $result->success ? 'success' : 'failed',
+                        'records_found'    => $result->recordsFound,
+                        'records_erased'   => $result->recordsErased,
+                        'records_retained' => $result->recordsRetained,
+                        'retention_reason' => $result->retentionReason,
+                        'backup_reference' => $this->encodeBackupReference( $result->backupData ),
+                        'error_message'    => $result->error,
+                        'completed_at'     => now(),
+                    ] );
+
+                    if ( $result->success ) {
+                        $processedHandlers[] = $name;
+                    } else {
+                        $failedHandlers[] = $name;
+                    }
+
+                    if ( $result->recordsRetained > 0 ) {
+                        $exemptions[] = [
+                            'handler'  => $name,
+                            'retained' => $result->recordsRetained,
+                            'reason'   => $result->retentionReason,
+                        ];
+                    }
+                } catch ( Exception $e ) {
+                    Log::error( "Erasure handler {$name} failed", [
+                        'request_id' => $request->id,
+                        'user_id'    => $request->user_id,
+                        'error'      => $e->getMessage(),
+                    ] );
+
+                    $log->update( [
+                        'status'        => 'failed',
+                        'error_message' => $e->getMessage(),
+                        'completed_at'  => now(),
+                    ] );
+
+                    $failedHandlers[] = $name;
+                }
+            }
+
+            $status = empty( $failedHandlers ) ? 'completed' : 'failed';
+            $request->update( [
+                'status'                => $status,
+                'handlers_processed'    => $processedHandlers,
+                'handlers_failed'       => $failedHandlers,
+                'exemptions_found'      => $exemptions,
+                'exemption_explanation' => ! empty( $exemptions )
+                    ? 'Some data was retained due to legal or contractual obligations'
+                    : null,
+                'completed_at' => now(),
+            ] );
+
+            // Generate certificate if configured
+            if ( config( 'artisanpack.compliance.compliance.erasure.generate_certificate', true ) ) {
+                $this->generateCertificate( $request );
+            }
+
+            event( new ErasureCompleted( $request ) );
+
+            return $request->fresh();
+        } );
+    }
+
+    /**
+     * Verify identity for erasure request.
+     */
+    public function verifyIdentity( ErasureRequest $request, string $method ): bool
+    {
+        $request->update( [
+            'identity_verified'        => true,
+            'identity_verified_at'     => now(),
+            'identity_verified_method' => $method,
+            'status'                   => 'approved',
+        ] );
+
+        return true;
+    }
+
+    /**
+     * Reject an erasure request.
+     */
+    public function rejectRequest( ErasureRequest $request, string $reason ): ErasureRequest
+    {
+        $request->update( [
+            'status'           => 'rejected',
+            'rejected_at'      => now(),
+            'rejected_by'      => auth()->id(),
+            'rejection_reason' => $reason,
+        ] );
+
+        return $request;
+    }
+
+    /**
+     * Get user data preview before erasure.
+     */
+    public function previewUserData( int $userId ): Collection
+    {
+        $preview = collect();
+
+        foreach ( $this->handlers as $name => $handler ) {
+            if ( ! $handler->canHandle( $userId ) ) {
+                continue;
+            }
+
+            $data = $handler->findUserData( $userId );
+            $preview->put( $name, [
+                'handler'        => $name,
+                'description'    => $handler->getDescription(),
+                'categories'     => $handler->getDataCategories(),
+                'record_count'   => $data->count(),
+                'estimated_time' => $handler->getEstimatedTime(),
+                'reversible'     => $handler->isReversible(),
+            ] );
+        }
+
+        return $preview;
+    }
+
+    /**
+     * Get pending requests for a user.
+     */
+    public function getPendingRequests( int $userId ): Collection
+    {
+        return ErasureRequest::where( 'user_id', $userId )
+            ->pending()
+            ->get();
+    }
+
+    /**
+     * Get all overdue requests.
+     */
+    public function getOverdueRequests(): Collection
+    {
+        return ErasureRequest::overdue()->get();
+    }
+
+    /**
+     * Notify third parties about erasure.
+     *
+     * @param  array<string>  $thirdParties
+     */
+    public function notifyThirdParties( ErasureRequest $request, array $thirdParties ): void
+    {
+        $notified = [];
+
+        foreach ( $thirdParties as $party ) {
+            // TODO: Implement actual notification logic
+            $notified[] = [
+                'party'       => $party,
+                'notified_at' => now()->toIso8601String(),
+                'method'      => 'email',
+            ];
+        }
+
+        $request->update( [
+            'third_parties_notified' => $notified,
+        ] );
+    }
+
+    /**
+     * Generate erasure certificate.
+     */
+    public function generateCertificate( ErasureRequest $request ): string
+    {
+        $certificate = [
+            'certificate_id'     => 'EC-' . $request->request_number,
+            'request_number'     => $request->request_number,
+            'user_id'            => $request->user_id,
+            'scope'              => $request->scope,
+            'completed_at'       => $request->completed_at?->toIso8601String(),
+            'handlers_processed' => $request->handlers_processed,
+            'exemptions'         => $request->exemptions_found,
+            'generated_at'       => now()->toIso8601String(),
+            'organization'       => config( 'app.name' ),
+        ];
+
+        // JSON_THROW_ON_ERROR so a malformed certificate payload fails
+        // loudly here rather than writing a `false` body and pretending
+        // to have generated a valid certificate.
+        $content = json_encode( $certificate, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT );
+        $path    = 'erasure-certificates/' . $request->request_number . '.json';
+
+        Storage::put( $path, $content );
+
+        $request->update( ['certificate_path' => $path] );
+
+        return $path;
+    }
+
+    /**
+     * Rollback an erasure if possible.
+     */
+    public function rollback( ErasureRequest $request ): bool
+    {
+        $logs            = $request->logs()->where( 'status', 'success' )->get();
+        $rollbackSuccess = true;
+
+        foreach ( $logs as $log ) {
+            $handler = $this->handlers[ $log->handler_name ] ?? null;
+
+            if ( ! $handler || ! $handler->isReversible() ) {
+                continue;
+            }
+
+            // Coerce malformed backups to an empty array so rollback()
+            // never receives null when json_decode silently fails.
+            $backupData = $log->backup_reference
+                ? ( json_decode( $log->backup_reference, true ) ?? [] )
+                : [];
+
+            try {
+                $handler->rollback( $request->user_id, $backupData );
+
+                ErasureLog::create( [
+                    'request_id'   => $request->id,
+                    'handler_name' => $log->handler_name,
+                    'action'       => 'rollback',
+                    'status'       => 'success',
+                    'started_at'   => now(),
+                    'completed_at' => now(),
+                ] );
+            } catch ( Exception $e ) {
+                $rollbackSuccess = false;
+
+                ErasureLog::create( [
+                    'request_id'    => $request->id,
+                    'handler_name'  => $log->handler_name,
+                    'action'        => 'rollback',
+                    'status'        => 'failed',
+                    'error_message' => $e->getMessage(),
+                    'started_at'    => now(),
+                    'completed_at'  => now(),
+                ] );
+            }
+        }
+
+        return $rollbackSuccess;
+    }
+
+    /**
+     * Create erasure log entry.
+     */
+    protected function createLog( ErasureRequest $request, string $handler, string $action ): ErasureLog
+    {
+        // Start as 'in_progress' — the row is updated to 'success' or
+        // 'failed' once the handler completes. Defaulting to 'success'
+        // here would mis-report any subsequent update() failure (e.g.
+        // database connectivity blip) as a successful erasure.
+        return ErasureLog::create( [
+            'request_id'   => $request->id,
+            'handler_name' => $handler,
+            'action'       => $action,
+            'status'       => 'in_progress',
+            'started_at'   => now(),
+        ] );
+    }
+
+    /**
+     * Encode a handler's backup payload for storage on the log row.
+     *
+     * Returns null on empty input or encode failure rather than letting
+     * `json_encode`'s `false` return get cast to a string and stored.
+     */
+    protected function encodeBackupReference( ?array $backupData ): ?string
+    {
+        if ( empty( $backupData ) ) {
+            return null;
+        }
+
+        try {
+            return json_encode( $backupData, JSON_THROW_ON_ERROR );
+        } catch ( JsonException $e ) {
+            Log::warning( 'ErasureService: failed to encode backup_reference', [
+                'message' => $e->getMessage(),
+            ] );
+
+            return null;
+        }
+    }
+}

--- a/src/Compliance/Erasure/ErasureService.php
+++ b/src/Compliance/Erasure/ErasureService.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use JsonException;
+use RuntimeException;
 
 class ErasureService
 {
@@ -71,7 +72,23 @@ class ErasureService
     public function processRequest( ErasureRequest $request ): ErasureRequest
     {
         return DB::transaction( function () use ( $request ) {
-            $request->update( ['status' => 'processing'] );
+            // Atomic claim: only an approved + identity-verified request
+            // that hasn't already entered processing should advance.
+            // The conditional UPDATE doubles as a lock — a second
+            // caller racing on the same row sees zero affected rows.
+            $updated = ErasureRequest::whereKey( $request->id )
+                ->where( 'status', 'approved' )
+                ->where( 'identity_verified', true )
+                ->update( ['status' => 'processing'] );
+
+            if ( 0 === $updated ) {
+                throw new RuntimeException(
+                    "Erasure request {$request->request_number} is not eligible for processing "
+                        . '(must be approved and identity-verified, and not already in progress).',
+                );
+            }
+
+            $request->refresh();
 
             $processedHandlers = [];
             $failedHandlers    = [];

--- a/src/Compliance/Erasure/ErasureService.php
+++ b/src/Compliance/Erasure/ErasureService.php
@@ -168,7 +168,7 @@ class ErasureService
             ] );
 
             // Generate certificate if configured
-            if ( config( 'artisanpack.compliance.compliance.erasure.generate_certificate', true ) ) {
+            if ( config( 'artisanpack.compliance.erasure.generate_certificate', true ) ) {
                 $this->generateCertificate( $request );
             }
 

--- a/src/Compliance/Erasure/Handlers/BaseErasureHandler.php
+++ b/src/Compliance/Erasure/Handlers/BaseErasureHandler.php
@@ -1,0 +1,136 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Erasure\Handlers;
+
+use ArtisanPackUI\Compliance\Compliance\Contracts\ErasureHandlerInterface;
+use ArtisanPackUI\Compliance\Compliance\Erasure\ErasureHandlerResult;
+use Illuminate\Support\Collection;
+
+abstract class BaseErasureHandler implements ErasureHandlerInterface
+{
+    /**
+     * Data categories handled by this handler.
+     *
+     * @var array<string>
+     */
+    protected array $dataCategories = [];
+
+    /**
+     * Retention exemption reasons.
+     *
+     * @var array<string>
+     */
+    protected array $exemptionReasons = [];
+
+    /**
+     * Whether this handler supports rollback.
+     */
+    protected bool $reversible = false;
+
+    /**
+     * Estimated time to complete in seconds.
+     */
+    protected int $estimatedTime = 30;
+
+    /**
+     * Get data categories handled.
+     *
+     * @return array<string>
+     */
+    public function getDataCategories(): array
+    {
+        return $this->dataCategories;
+    }
+
+    /**
+     * Check if erasure is reversible.
+     */
+    public function isReversible(): bool
+    {
+        return $this->reversible;
+    }
+
+    /**
+     * Get estimated time to complete.
+     */
+    public function getEstimatedTime(): int
+    {
+        return $this->estimatedTime;
+    }
+
+    /**
+     * Rollback erasure (default implementation - override if reversible).
+     *
+     * @param  array<string, mixed>  $backupData
+     */
+    public function rollback( int $userId, array $backupData ): bool
+    {
+        return false;
+    }
+
+    /**
+     * Check for retention exemptions.
+     *
+     * @return array<string, mixed>
+     */
+    protected function checkExemptions( int $userId ): array
+    {
+        return [];
+    }
+
+    /**
+     * Create backup before erasure.
+     *
+     * @return array<string, mixed>
+     */
+    protected function createBackup( Collection $data ): array
+    {
+        if ( ! $this->reversible ) {
+            return [];
+        }
+
+        return $data->toArray();
+    }
+
+    /**
+     * Log erasure action.
+     *
+     * @param  array<string, mixed>  $context
+     */
+    protected function logErasure( string $action, array $context = [] ): void
+    {
+        \Illuminate\Support\Facades\Log::info( "Erasure: {$action}", array_merge( [
+            'handler' => $this->getName(),
+        ], $context ) );
+    }
+
+    /**
+     * Create a successful result.
+     *
+     * @param  array<string, mixed>  $backup
+     */
+    protected function success( int $found, int $erased, int $retained = 0, array $backup = [] ): ErasureHandlerResult
+    {
+        return ErasureHandlerResult::success( $found, $erased, $retained, $backup );
+    }
+
+    /**
+     * Create a failed result.
+     */
+    protected function failed( string $error, int $found = 0 ): ErasureHandlerResult
+    {
+        return ErasureHandlerResult::failed( $error, $found );
+    }
+
+    /**
+     * Create a partial result with retained records.
+     *
+     * @param  array<string, mixed>  $retained
+     */
+    protected function partial( int $found, int $erased, array $retained, string $reason ): ErasureHandlerResult
+    {
+        return ErasureHandlerResult::partial( $found, $erased, $retained, $reason);
+    }
+}

--- a/src/Compliance/Erasure/Handlers/ConsentRecordsHandler.php
+++ b/src/Compliance/Erasure/Handlers/ConsentRecordsHandler.php
@@ -39,7 +39,12 @@ class ConsentRecordsHandler extends BaseErasureHandler
      */
     public function canHandle( int $userId ): bool
     {
-        return ConsentRecord::where( 'user_id', $userId )->exists();
+        // Cover users who only have audit-log entries (e.g. after an
+        // earlier withdraw + soft-delete cycle) — otherwise erase()
+        // would skip them and the audit logs would survive a "right
+        // to be forgotten" request.
+        return ConsentRecord::where( 'user_id', $userId )->exists()
+            || ConsentAuditLog::where( 'user_id', $userId )->exists();
     }
 
     /**

--- a/src/Compliance/Erasure/Handlers/ConsentRecordsHandler.php
+++ b/src/Compliance/Erasure/Handlers/ConsentRecordsHandler.php
@@ -63,24 +63,27 @@ class ConsentRecordsHandler extends BaseErasureHandler
         $this->logErasure( 'starting', ['user_id' => $userId] );
 
         try {
-            $consentCount = ConsentRecord::where( 'user_id', $userId )->count();
-            $auditCount   = ConsentAuditLog::where( 'user_id', $userId )->count();
+            // Wrap both deletes in a single transaction so a failure
+            // halfway through can't leave consents deleted but audit
+            // logs intact (or vice versa) with mismatched reported
+            // counts.
+            return \Illuminate\Support\Facades\DB::transaction( function () use ( $userId ) {
+                $consentCount = ConsentRecord::where( 'user_id', $userId )->count();
+                $auditCount   = ConsentAuditLog::where( 'user_id', $userId )->count();
 
-            $totalFound = $consentCount + $auditCount;
+                $totalFound = $consentCount + $auditCount;
 
-            // Delete consent records
-            ConsentRecord::where( 'user_id', $userId )->delete();
+                ConsentRecord::where( 'user_id', $userId )->delete();
+                ConsentAuditLog::where( 'user_id', $userId )->delete();
 
-            // Delete audit logs
-            ConsentAuditLog::where( 'user_id', $userId )->delete();
+                $this->logErasure( 'completed', [
+                    'user_id'         => $userId,
+                    'consent_records' => $consentCount,
+                    'audit_logs'      => $auditCount,
+                ] );
 
-            $this->logErasure( 'completed', [
-                'user_id'         => $userId,
-                'consent_records' => $consentCount,
-                'audit_logs'      => $auditCount,
-            ] );
-
-            return $this->success( $totalFound, $totalFound );
+                return $this->success( $totalFound, $totalFound );
+            } );
         } catch ( Exception $e ) {
             $this->logErasure( 'failed', ['user_id' => $userId, 'error' => $e->getMessage()] );
 

--- a/src/Compliance/Erasure/Handlers/ConsentRecordsHandler.php
+++ b/src/Compliance/Erasure/Handlers/ConsentRecordsHandler.php
@@ -1,0 +1,90 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Erasure\Handlers;
+
+use ArtisanPackUI\Compliance\Compliance\Erasure\ErasureHandlerResult;
+use ArtisanPackUI\Compliance\Models\ConsentAuditLog;
+use ArtisanPackUI\Compliance\Models\ConsentRecord;
+use Exception;
+use Illuminate\Support\Collection;
+
+class ConsentRecordsHandler extends BaseErasureHandler
+{
+    protected array $dataCategories = ['consent', 'preferences'];
+
+    protected bool $reversible = false;
+
+    protected int $estimatedTime = 15;
+
+    /**
+     * Get handler name.
+     */
+    public function getName(): string
+    {
+        return 'consent_records';
+    }
+
+    /**
+     * Get handler description.
+     */
+    public function getDescription(): string
+    {
+        return 'Handles consent records and audit log erasure';
+    }
+
+    /**
+     * Check if handler can process for user.
+     */
+    public function canHandle( int $userId ): bool
+    {
+        return ConsentRecord::where( 'user_id', $userId )->exists();
+    }
+
+    /**
+     * Find all user consent data.
+     */
+    public function findUserData( int $userId ): Collection
+    {
+        return collect( [
+            'consent_records' => ConsentRecord::where( 'user_id', $userId )->get(),
+            'audit_logs'      => ConsentAuditLog::where( 'user_id', $userId )->get(),
+        ] );
+    }
+
+    /**
+     * Execute erasure.
+     *
+     * @param  array<string, mixed>  $options
+     */
+    public function erase( int $userId, array $options = [] ): ErasureHandlerResult
+    {
+        $this->logErasure( 'starting', ['user_id' => $userId] );
+
+        try {
+            $consentCount = ConsentRecord::where( 'user_id', $userId )->count();
+            $auditCount   = ConsentAuditLog::where( 'user_id', $userId )->count();
+
+            $totalFound = $consentCount + $auditCount;
+
+            // Delete consent records
+            ConsentRecord::where( 'user_id', $userId )->delete();
+
+            // Delete audit logs
+            ConsentAuditLog::where( 'user_id', $userId )->delete();
+
+            $this->logErasure( 'completed', [
+                'user_id'         => $userId,
+                'consent_records' => $consentCount,
+                'audit_logs'      => $auditCount,
+            ] );
+
+            return $this->success( $totalFound, $totalFound );
+        } catch ( Exception $e ) {
+            $this->logErasure( 'failed', ['user_id' => $userId, 'error' => $e->getMessage()] );
+
+            return $this->failed( $e->getMessage() );
+        }
+    }
+}

--- a/src/Compliance/Erasure/Handlers/UserProfileHandler.php
+++ b/src/Compliance/Erasure/Handlers/UserProfileHandler.php
@@ -1,0 +1,142 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Erasure\Handlers;
+
+use ArtisanPackUI\Compliance\Compliance\Erasure\ErasureHandlerResult;
+use Exception;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+class UserProfileHandler extends BaseErasureHandler
+{
+    protected array $dataCategories = ['identity', 'contact', 'profile'];
+
+    protected bool $reversible = true;
+
+    protected int $estimatedTime = 10;
+
+    /**
+     * Get handler name.
+     */
+    public function getName(): string
+    {
+        return 'user_profile';
+    }
+
+    /**
+     * Get handler description.
+     */
+    public function getDescription(): string
+    {
+        return 'Handles user profile and account data erasure';
+    }
+
+    /**
+     * Check if handler can process for user.
+     */
+    public function canHandle( int $userId ): bool
+    {
+        $userModel = config( 'auth.providers.users.model' );
+
+        return null !== $userModel::find( $userId );
+    }
+
+    /**
+     * Find all user data.
+     */
+    public function findUserData( int $userId ): Collection
+    {
+        $userModel = config( 'auth.providers.users.model' );
+        $user      = $userModel::find( $userId );
+
+        if ( ! $user ) {
+            return collect();
+        }
+
+        return collect( [
+            'user' => $user->toArray(),
+        ] );
+    }
+
+    /**
+     * Execute erasure.
+     *
+     * @param  array<string, mixed>  $options
+     */
+    public function erase( int $userId, array $options = [] ): ErasureHandlerResult
+    {
+        $userModel = config( 'auth.providers.users.model' );
+        $user      = $userModel::find( $userId );
+
+        if ( ! $user ) {
+            return $this->failed( 'User not found', 0 );
+        }
+
+        $backup = $this->createBackup( collect( [$user->toArray()] ) );
+
+        $this->logErasure( 'starting', ['user_id' => $userId] );
+
+        try {
+            // Anonymize rather than delete to maintain referential integrity
+            $anonymizedEmail = 'deleted_' . Str::random( 16 ) . '@anonymized.local';
+            $user->update( [
+                'name'     => 'Deleted User',
+                'email'    => $anonymizedEmail,
+                'password' => Hash::make( Str::random( 64 ) ),
+                // Add other fields as necessary
+            ] );
+
+            // Optionally soft delete if supported
+            if ( method_exists( $user, 'trashed' ) && ! $user->trashed() ) {
+                $user->delete();
+            }
+
+            $this->logErasure( 'completed', ['user_id' => $userId] );
+
+            return $this->success( 1, 1, 0, $backup );
+        } catch ( Exception $e ) {
+            $this->logErasure( 'failed', ['user_id' => $userId, 'error' => $e->getMessage()] );
+
+            return $this->failed( $e->getMessage(), 1 );
+        }
+    }
+
+    /**
+     * Rollback erasure.
+     *
+     * @param  array<string, mixed>  $backupData
+     */
+    public function rollback( int $userId, array $backupData ): bool
+    {
+        if ( empty( $backupData ) ) {
+            return false;
+        }
+
+        $userModel = config( 'auth.providers.users.model' );
+        $query     = $userModel::query();
+        if ( method_exists( $userModel, 'withTrashed' ) ) {
+            $query = $userModel::withTrashed();
+        }
+        $user = $query->find( $userId );
+
+        if ( ! $user ) {
+            return false;
+        }
+
+        // Restore soft deleted user
+        if ( method_exists( $user, 'restore' ) ) {
+            $user->restore();
+        }
+
+        // Restore original data
+        $originalData = $backupData[0] ?? [];
+        unset( $originalData['id'], $originalData['created_at'], $originalData['updated_at'], $originalData['deleted_at'] );
+
+        $user->update( $originalData );
+
+        return true;
+    }
+}

--- a/src/Compliance/Exceptions/DecryptionException.php
+++ b/src/Compliance/Exceptions/DecryptionException.php
@@ -1,0 +1,38 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Exceptions;
+
+use RuntimeException;
+use Throwable;
+
+/**
+ * Thrown when a sensitive attribute can't be decrypted at read time.
+ *
+ * Distinguishes "stored ciphertext is unreadable" (rotated app key,
+ * legacy / tampered payload) from "value is plaintext or absent",
+ * so callers can refuse to export, pseudonymize, or otherwise act
+ * on opaque ciphertext as if it were a real value.
+ */
+class DecryptionException extends RuntimeException
+{
+    public function __construct(
+        public readonly string $attribute,
+        public readonly string $modelClass,
+        public readonly mixed $modelKey,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct(
+            sprintf(
+                'PrivacyByDesign: failed to decrypt sensitive attribute "%s" on %s#%s '
+                    . '(unreadable ciphertext — possible app-key rotation or tampered payload).',
+                $attribute,
+                $modelClass,
+                (string) ( $modelKey ?? 'unsaved' ),
+            ),
+            0,
+            $previous,
+        );
+    }
+}

--- a/src/Compliance/Middleware/CheckConsentMiddleware.php
+++ b/src/Compliance/Middleware/CheckConsentMiddleware.php
@@ -1,0 +1,51 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Middleware;
+
+use ArtisanPackUI\Compliance\Compliance\Consent\ConsentManager;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckConsentMiddleware
+{
+    public function __construct( protected ConsentManager $consentManager )
+    {
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle( Request $request, Closure $next, string $purpose ): Response
+    {
+        $user = $request->user();
+
+        if ( ! $user ) {
+            return $next( $request );
+        }
+
+        $verification = $this->consentManager->verifyConsent( $user->id, $purpose );
+
+        if ( ! $verification->isValid ) {
+            if ( $verification->requiresReconsent ) {
+                return response()->json( [
+                    'error'   => 'reconsent_required',
+                    'message' => 'Please update your consent preferences.',
+                    'purpose' => $purpose,
+                ], 403 );
+            }
+
+            return response()->json( [
+                'error'   => 'consent_required',
+                'message' => 'Consent is required to access this resource.',
+                'purpose' => $purpose,
+            ], 403 );
+        }
+
+        return $next( $request );
+    }
+}

--- a/src/Compliance/Middleware/DataMinimizationMiddleware.php
+++ b/src/Compliance/Middleware/DataMinimizationMiddleware.php
@@ -23,7 +23,7 @@ class DataMinimizationMiddleware
     public function handle( Request $request, Closure $next, string $purpose ): Response
     {
         // Validate collection if configured
-        if ( config( 'artisanpack.compliance.compliance.minimization.enforce_collection_policies', true ) ) {
+        if ( config( 'artisanpack.compliance.minimization.enforce_collection_policies', true ) ) {
             $validation = $this->minimizer->validateCollection(
                 $request->all(),
                 $purpose,

--- a/src/Compliance/Middleware/DataMinimizationMiddleware.php
+++ b/src/Compliance/Middleware/DataMinimizationMiddleware.php
@@ -1,0 +1,51 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Middleware;
+
+use ArtisanPackUI\Compliance\Compliance\Minimization\DataMinimizerService;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class DataMinimizationMiddleware
+{
+    public function __construct( protected DataMinimizerService $minimizer )
+    {
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle( Request $request, Closure $next, string $purpose ): Response
+    {
+        // Validate collection if configured
+        if ( config( 'artisanpack.compliance.compliance.minimization.enforce_collection_policies', true ) ) {
+            $validation = $this->minimizer->validateCollection(
+                $request->all(),
+                $purpose,
+            );
+
+            if ( ! $validation->isValid ) {
+                return response()->json( [
+                    'error'   => 'data_minimization_violation',
+                    'message' => 'Request contains prohibited or unnecessary data.',
+                    'errors'  => $validation->errors,
+                ], 422 );
+            }
+
+            // Filter request data to allowed fields only
+            $filteredData = $this->minimizer->applyCollectionPolicy(
+                $request->all(),
+                $purpose,
+            );
+
+            $request->replace( $filteredData );
+        }
+
+        return $next( $request );
+    }
+}

--- a/src/Compliance/Minimization/AnonymizationEngine.php
+++ b/src/Compliance/Minimization/AnonymizationEngine.php
@@ -1,0 +1,379 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Minimization;
+
+use DateTime;
+use DateTimeInterface;
+use Exception;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+
+class AnonymizationEngine
+{
+    /**
+     * @var array<string, callable>
+     */
+    protected array $strategies = [];
+
+    public function __construct()
+    {
+        $this->registerDefaultStrategies();
+    }
+
+    /**
+     * Anonymize a single value.
+     */
+    public function anonymizeValue( mixed $value, string $type ): mixed
+    {
+        if ( null === $value ) {
+            return null;
+        }
+
+        if ( isset( $this->strategies[ $type ] ) ) {
+            return ( $this->strategies[ $type ] )( $value );
+        }
+
+        return $this->defaultAnonymize( $value );
+    }
+
+    /**
+     * Get available anonymization strategies.
+     *
+     * @return array<string>
+     */
+    public function getStrategies(): array
+    {
+        return array_keys( $this->strategies );
+    }
+
+    /**
+     * Generalize a value (k-anonymity).
+     */
+    public function generalize( mixed $value, string $type, int $level = 1 ): mixed
+    {
+        return match ( $type ) {
+            'date'     => $this->generalizeDate( $value, $level ),
+            'age'      => $this->generalizeAge( $value, $level ),
+            'number'   => $this->generalizeNumber( $value, $level ),
+            'location' => $this->generalizeLocation( $value, $level ),
+            default    => $this->defaultGeneralize( $value, $level ),
+        };
+    }
+
+    /**
+     * Suppress a value (remove completely).
+     */
+    public function suppress( mixed $value ): null
+    {
+        return null;
+    }
+
+    /**
+     * Add noise for differential privacy.
+     */
+    public function addNoise( float $value, float $epsilon ): float
+    {
+        // Laplace mechanism for differential privacy. Uses a CSPRNG
+        // (random_int) — mt_rand() doesn't give the entropy guarantees
+        // differential privacy assumes — and clamps `u` away from the
+        // ±0.5 boundary so 1 - 2*|u| can't hit 0 and produce log(0)/-INF.
+        $scale = 1 / $epsilon;
+        $u     = random_int( 1, PHP_INT_MAX - 1 ) / PHP_INT_MAX - 0.5;
+        $u     = max( -0.4999999, min( 0.4999999, $u ) );
+        $noise = -$scale * ( ( $u > 0 ? 1 : -1 ) * log( 1 - 2 * abs( $u ) ) );
+
+        return $value + $noise;
+    }
+
+    /**
+     * Hash with salt for pseudonymization.
+     */
+    public function hash( string $value, string $salt ): string
+    {
+        return hash( 'sha256', $value . $salt );
+    }
+
+    /**
+     * Tokenize (reversible with key).
+     */
+    public function tokenize( string $value ): string
+    {
+        return encrypt( $value );
+    }
+
+    /**
+     * Mask partial data.
+     */
+    public function mask( string $value, string $type ): string
+    {
+        return match ( $type ) {
+            'email'       => $this->maskEmail( $value ),
+            'phone'       => $this->maskPhone( $value ),
+            'credit_card' => $this->maskCreditCard( $value ),
+            'ssn'         => $this->maskSsn( $value ),
+            default       => $this->defaultMask( $value ),
+        };
+    }
+
+    /**
+     * Validate k-anonymity of dataset.
+     *
+     * @param  array<string>  $quasiIdentifiers
+     */
+    public function validateKAnonymity( Collection $data, array $quasiIdentifiers, int $k ): bool
+    {
+        $groups = $data->groupBy( function ( $item ) use ( $quasiIdentifiers ) {
+            $key = [];
+            foreach ( $quasiIdentifiers as $qi ) {
+                $key[] = is_array( $item ) ? ( $item[ $qi ] ?? '' ) : ( $item->$qi ?? '' );
+            }
+
+            return implode( '|', $key );
+        } );
+
+        foreach ( $groups as $group ) {
+            if ( $group->count() < $k ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Register a custom anonymization strategy.
+     */
+    public function registerStrategy( string $type, callable $strategy ): void
+    {
+        $this->strategies[ $type ] = $strategy;
+    }
+
+    /**
+     * Register default anonymization strategies.
+     */
+    protected function registerDefaultStrategies(): void
+    {
+        $this->strategies['email']       = fn ( $value ) => $this->maskEmail( $value );
+        $this->strategies['phone']       = fn ( $value ) => $this->maskPhone( $value );
+        $this->strategies['name']        = fn ( $value ) => $this->anonymizeName( $value );
+        $this->strategies['address']     = fn ( $value ) => '[ADDRESS REDACTED]';
+        $this->strategies['date']        = fn ( $value ) => $this->generalizeDate( $value, 1 );
+        $this->strategies['number']      = fn ( $value ) => $this->generalizeNumber( $value, 1 );
+        $this->strategies['ip']          = fn ( $value ) => $this->anonymizeIp( $value );
+        $this->strategies['credit_card'] = fn ( $value ) => $this->maskCreditCard( $value );
+        $this->strategies['ssn']         = fn ( $value ) => $this->maskSsn( $value );
+    }
+
+    /**
+     * Default anonymization for unknown types.
+     */
+    protected function defaultAnonymize( mixed $value ): mixed
+    {
+        if ( is_string( $value ) ) {
+            $length = strlen( $value );
+            if ( $length <= 2 ) {
+                return str_repeat( '*', $length );
+            }
+
+            return Str::mask( $value, '*', 1, $length - 2 );
+        }
+
+        if ( is_numeric( $value ) ) {
+            return $this->generalizeNumber( $value, 1 );
+        }
+
+        return '[REDACTED]';
+    }
+
+    /**
+     * Mask email address.
+     */
+    protected function maskEmail( string $email ): string
+    {
+        if ( ! filter_var( $email, FILTER_VALIDATE_EMAIL ) ) {
+            return $this->defaultMask( $email );
+        }
+
+        [$local, $domain] = explode( '@', $email );
+        $maskedLocal      = strlen( $local ) > 2
+            ? $local[0] . str_repeat( '*', strlen( $local ) - 2 ) . $local[-1]
+            : str_repeat( '*', strlen( $local ) );
+
+        return $maskedLocal . '@' . $domain;
+    }
+
+    /**
+     * Mask phone number.
+     */
+    protected function maskPhone( string $phone ): string
+    {
+        $digits = preg_replace( '/[^\d]/', '', $phone );
+        $length = strlen( $digits );
+
+        if ( $length <= 4 ) {
+            return str_repeat( '*', $length );
+        }
+
+        return str_repeat( '*', $length - 4 ) . substr( $digits, -4 );
+    }
+
+    /**
+     * Mask credit card number.
+     */
+    protected function maskCreditCard( string $card ): string
+    {
+        $digits = preg_replace( '/[^\d]/', '', $card );
+        if ( strlen( $digits ) <= 4 ) {
+            return str_repeat( '*', strlen( $digits ) );
+        }
+
+        return str_repeat( '*', strlen( $digits ) - 4 ) . substr( $digits, -4 );
+    }
+
+    /**
+     * Mask SSN.
+     */
+    protected function maskSsn( string $ssn ): string
+    {
+        $digits = preg_replace( '/[^\d]/', '', $ssn );
+        if ( strlen( $digits ) < 4 ) {
+            return str_repeat( '*', strlen( $digits ) );
+        }
+
+        return '***-**-' . substr( $digits, -4 );
+    }
+
+    /**
+     * Default masking.
+     */
+    protected function defaultMask( string $value ): string
+    {
+        $length = strlen( $value );
+        if ( $length <= 4 ) {
+            return str_repeat( '*', $length );
+        }
+
+        return substr( $value, 0, 2 ) . str_repeat( '*', $length - 4 ) . substr( $value, -2 );
+    }
+
+    /**
+     * Anonymize a name.
+     */
+    protected function anonymizeName( string $name ): string
+    {
+        $parts = explode( ' ', $name );
+
+        return implode( ' ', array_map( function ( $part ) {
+            return strlen( $part ) > 0 ? $part[0] . str_repeat( '*', strlen( $part ) - 1 ) : '';
+        }, $parts ) );
+    }
+
+    /**
+     * Anonymize an IP address.
+     */
+    protected function anonymizeIp( string $ip ): string
+    {
+        if ( filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
+            $parts    = explode( '.', $ip );
+            $parts[3] = '0';
+
+            return implode( '.', $parts );
+        }
+
+        if ( filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 ) ) {
+            // Convert to binary, zero out last 64 bits (8 bytes), convert back
+            // This handles both full and compressed IPv6 notation correctly
+            $binary = inet_pton( $ip );
+            if ( false === $binary ) {
+                return '::';
+            }
+
+            // Zero out the last 8 bytes (64 bits) for /64 anonymization
+            $binary = substr( $binary, 0, 8 ) . str_repeat( "\0", 8 );
+
+            $anonymized = inet_ntop( $binary );
+
+            return false !== $anonymized ? $anonymized : '::';
+        }
+
+        return '0.0.0.0';
+    }
+
+    /**
+     * Generalize a date.
+     */
+    protected function generalizeDate( mixed $value, int $level ): string
+    {
+        try {
+            $date = $value instanceof DateTimeInterface
+                ? $value
+                : new DateTime( $value );
+        } catch ( Exception $e ) {
+            // Malformed date input shouldn't crash the whole
+            // anonymization pass — return an explicit marker so the
+            // record is visibly redacted rather than silently broken.
+            return '[INVALID DATE]';
+        }
+
+        return match ( $level ) {
+            1       => $date->format( 'Y-m' ),  // Month/Year
+            2       => $date->format( 'Y' ),     // Year only
+            3       => (string) ( floor( (int) $date->format( 'Y' ) / 5 ) * 5 ) . '-' . (string) ( floor( (int) $date->format( 'Y' ) / 5 ) * 5 + 4 ), // 5-year range
+            default => $date->format( 'Y-m' ),
+        };
+    }
+
+    /**
+     * Generalize age.
+     */
+    protected function generalizeAge( int $age, int $level ): string
+    {
+        $range = match ( $level ) {
+            1       => 5,
+            2       => 10,
+            3       => 20,
+            default => 5,
+        };
+
+        $lower = floor( $age / $range ) * $range;
+        $upper = $lower + $range - 1;
+
+        return "{$lower}-{$upper}";
+    }
+
+    /**
+     * Generalize a number.
+     */
+    protected function generalizeNumber( mixed $value, int $level ): mixed
+    {
+        $value     = (float) $value;
+        $magnitude = pow( 10, $level );
+
+        return floor( $value / $magnitude ) * $magnitude;
+    }
+
+    /**
+     * Generalize location (zip code).
+     */
+    protected function generalizeLocation( string $value, int $level ): string
+    {
+        $length = strlen( $value );
+        $keep   = max( 1, $length - $level );
+
+        return substr( $value, 0, $keep ) . str_repeat( '*', $length - $keep );
+    }
+
+    /**
+     * Default generalization.
+     */
+    protected function defaultGeneralize( mixed $value, int $level ): mixed
+    {
+        if ( is_string( $value ) ) {
+            return substr( $value, 0, max( 1, strlen( $value) - $level));
+        }
+
+        return $value;
+    }
+}

--- a/src/Compliance/Minimization/DataMinimizerService.php
+++ b/src/Compliance/Minimization/DataMinimizerService.php
@@ -177,7 +177,7 @@ class DataMinimizerService
             return 0;
         }
 
-        $batchSize = config( 'artisanpack.compliance.compliance.minimization.purge_batch_size', 1000 );
+        $batchSize = config( 'artisanpack.compliance.minimization.purge_batch_size', 1000 );
 
         $count = 0;
         do {

--- a/src/Compliance/Minimization/DataMinimizerService.php
+++ b/src/Compliance/Minimization/DataMinimizerService.php
@@ -1,0 +1,241 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Minimization;
+
+use ArtisanPackUI\Compliance\Compliance\Validation\ValidationResult;
+use ArtisanPackUI\Compliance\Models\CollectionPolicy;
+use DateTimeInterface;
+use Illuminate\Support\Collection;
+
+class DataMinimizerService
+{
+    protected AnonymizationEngine $anonymizer;
+
+    protected PseudonymizationEngine $pseudonymizer;
+
+    /**
+     * @var array<string, CollectionPolicy>
+     */
+    protected array $policies = [];
+
+    public function __construct(
+        AnonymizationEngine $anonymizer,
+        PseudonymizationEngine $pseudonymizer,
+    ) {
+        $this->anonymizer    = $anonymizer;
+        $this->pseudonymizer = $pseudonymizer;
+    }
+
+    /**
+     * Apply collection policy to incoming data.
+     *
+     * @param  array<string, mixed>  $data
+     *
+     * @return array<string, mixed>
+     */
+    public function applyCollectionPolicy( array $data, string $purpose ): array
+    {
+        $policy = $this->getCollectionPolicy( $purpose );
+
+        if ( ! $policy ) {
+            return $data;
+        }
+
+        return $policy->filterData( $data );
+    }
+
+    /**
+     * Check if data collection is compliant.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function validateCollection( array $data, string $purpose ): ValidationResult
+    {
+        $policy = $this->getCollectionPolicy( $purpose );
+
+        if ( ! $policy ) {
+            return ValidationResult::valid();
+        }
+
+        $errors   = [];
+        $warnings = [];
+
+        // Check for missing required fields
+        $missingRequired = $policy->getMissingRequiredFields( $data );
+        foreach ( $missingRequired as $field ) {
+            $errors[] = "Required field '{$field}' is missing for purpose '{$purpose}'";
+        }
+
+        // Check for prohibited fields
+        $prohibited = $policy->prohibited_fields ?? [];
+        foreach ( array_keys( $data ) as $field ) {
+            if ( in_array( $field, $prohibited ) ) {
+                $errors[] = "Field '{$field}' is prohibited for purpose '{$purpose}'";
+            }
+        }
+
+        // Check for unnecessary fields (not in allowed)
+        $allowed = $policy->allowed_fields ?? [];
+        if ( ! empty( $allowed ) ) {
+            foreach ( array_keys( $data ) as $field ) {
+                if ( ! in_array( $field, $allowed ) && ! in_array( $field, $prohibited ) ) {
+                    $warnings[] = "Field '{$field}' may be unnecessary for purpose '{$purpose}'";
+                }
+            }
+        }
+
+        return new ValidationResult(
+            isValid: empty( $errors ),
+            errors: $errors,
+            warnings: $warnings,
+        );
+    }
+
+    /**
+     * Anonymize dataset.
+     *
+     * @param  array<string>  $fields
+     */
+    public function anonymize( Collection $data, array $fields ): Collection
+    {
+        return $data->map( function ( $item ) use ( $fields ) {
+            $itemArray = is_array( $item ) ? $item : $item->toArray();
+
+            foreach ( $fields as $field ) {
+                if ( isset( $itemArray[ $field ] ) ) {
+                    $itemArray[ $field ] = $this->anonymizer->anonymizeValue(
+                        $itemArray[ $field ],
+                        $this->detectType( $itemArray[ $field ] ),
+                    );
+                }
+            }
+
+            return $itemArray;
+        } );
+    }
+
+    /**
+     * Pseudonymize dataset.
+     *
+     * @param  array<string>  $fields
+     */
+    public function pseudonymize( Collection $data, array $fields ): PseudonymizedResult
+    {
+        $pseudonymizedData = $data->map( function ( $item ) use ( $fields ) {
+            $itemArray = is_array( $item ) ? $item : $item->toArray();
+
+            foreach ( $fields as $field ) {
+                if ( isset( $itemArray[ $field ] ) ) {
+                    $itemArray[ $field ] = $this->pseudonymizer->pseudonymize(
+                        (string) $itemArray[ $field ],
+                        $field,
+                    );
+                }
+            }
+
+            return $itemArray;
+        } );
+
+        return new PseudonymizedResult(
+            data: $pseudonymizedData,
+            mappingKey: $this->pseudonymizer->getCurrentMappingKey(),
+        );
+    }
+
+    /**
+     * Reverse pseudonymization (with authorization).
+     */
+    public function dePseudonymize( string $pseudonym, string $field ): ?string
+    {
+        return $this->pseudonymizer->dePseudonymize( $pseudonym, $field );
+    }
+
+    /**
+     * Get data that has exceeded retention period.
+     *
+     * @param  class-string  $model
+     */
+    public function getExpiredData( string $model ): Collection
+    {
+        if ( ! method_exists( $model, 'scopeExpiredRetention' ) ) {
+            return collect();
+        }
+
+        return $model::expiredRetention()->get();
+    }
+
+    /**
+     * Purge expired data.
+     *
+     * @param  class-string  $model
+     */
+    public function purgeExpiredData( string $model ): int
+    {
+        if ( ! method_exists( $model, 'scopeExpiredRetention' ) ) {
+            return 0;
+        }
+
+        $batchSize = config( 'artisanpack.compliance.compliance.minimization.purge_batch_size', 1000 );
+
+        $count = 0;
+        do {
+            $deleted = $model::expiredRetention()
+                ->limit( $batchSize )
+                ->delete();
+            $count += $deleted;
+        } while ( $deleted > 0 );
+
+        return $count;
+    }
+
+    /**
+     * Get collection policy for purpose.
+     */
+    public function getCollectionPolicy( string $purpose ): ?CollectionPolicy
+    {
+        if ( isset( $this->policies[ $purpose ] ) ) {
+            return $this->policies[ $purpose ];
+        }
+
+        $policy = CollectionPolicy::getForPurpose( $purpose );
+        if ( $policy ) {
+            $this->policies[ $purpose ] = $policy;
+        }
+
+        return $policy;
+    }
+
+    /**
+     * Register a collection policy.
+     */
+    public function registerPolicy( string $purpose, CollectionPolicy $policy ): void
+    {
+        $this->policies[ $purpose ] = $policy;
+    }
+
+    /**
+     * Detect the type of a value for appropriate anonymization.
+     */
+    protected function detectType( mixed $value ): string
+    {
+        if ( filter_var( $value, FILTER_VALIDATE_EMAIL ) ) {
+            return 'email';
+        }
+
+        if ( is_string( $value ) && preg_match( '/^[\d\s\-\+\(\)]+$/', $value ) && strlen( $value ) >= 7 ) {
+            return 'phone';
+        }
+
+        if ( is_numeric( $value ) ) {
+            return 'number';
+        }
+
+        if ( $value instanceof DateTimeInterface ) {
+            return 'date';
+        }
+
+        return 'string';
+    }
+}

--- a/src/Compliance/Minimization/PseudonymizationEngine.php
+++ b/src/Compliance/Minimization/PseudonymizationEngine.php
@@ -1,0 +1,248 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Minimization;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+
+class PseudonymizationEngine
+{
+	/**
+	 * Cache key for tracking all mapping keys (for cleanup).
+	 */
+	protected const MAPPING_INDEX_KEY = 'pseudonym_mapping_keys_index';
+
+	protected string $currentMappingKey;
+
+	protected bool $storeMappings = true;
+
+	/**
+	 * @var array<string, string>
+	 */
+	protected array $mappingCache = [];
+
+	public function __construct()
+	{
+		$this->currentMappingKey = $this->generateMappingKey();
+	}
+
+	/**
+	 * Get current mapping key.
+	 */
+	public function getCurrentMappingKey(): string
+	{
+		return $this->currentMappingKey;
+	}
+
+	/**
+	 * Set mapping key for consistency across operations.
+	 */
+	public function setMappingKey( string $key ): void
+	{
+		$this->currentMappingKey = $key;
+	}
+
+	/**
+	 * Enable or disable mapping storage.
+	 */
+	public function setStoreMappings( bool $store ): void
+	{
+		$this->storeMappings = $store;
+	}
+
+	/**
+	 * Clear all stored mappings (both in-memory and persistent).
+	 */
+	public function clearMappings(): void
+	{
+		// Get tracked keys from cache index
+		$trackedKeys = Cache::get( self::MAPPING_INDEX_KEY, [] );
+		$trackedKeys = is_array( $trackedKeys ) ? $trackedKeys : [];
+
+		// Delete all tracked persistent mappings
+		foreach ( $trackedKeys as $cacheKey ) {
+			Cache::forget( $cacheKey );
+		}
+
+		// Clear the index itself
+		Cache::forget( self::MAPPING_INDEX_KEY );
+
+		// Clear in-memory cache
+		$this->mappingCache = [];
+		// Note: This doesn't clear the Cache store
+		// Implement cache clearing logic based on your cache driver
+	}
+
+	/**
+	 * Check if a pseudonym exists.
+	 */
+	public function exists( string $pseudonym, string $field ): bool
+	{
+		return null !== $this->dePseudonymize( $pseudonym, $field );
+	}
+
+	/**
+	 * Reverse pseudonymization.
+	 */
+	public function dePseudonymize( string $pseudonym, string $field ): ?string
+	{
+		$cacheKey = $this->getMappingCacheKey( $pseudonym, $field );
+
+		if ( isset( $this->mappingCache[ $cacheKey ] ) ) {
+			return $this->mappingCache[ $cacheKey ];
+		}
+
+		$value = Cache::get( $cacheKey );
+
+		if ( null !== $value ) {
+			$this->mappingCache[ $cacheKey ] = $value;
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Create a pseudonym token (shorter, for display).
+	 */
+	public function createToken( string $value, string $field ): string
+	{
+		$pseudonym = $this->pseudonymize( $value, $field );
+
+		// Return first 12 characters for display purposes
+		return substr( $pseudonym, 0, 12 );
+	}
+
+	/**
+	 * Pseudonymize a value.
+	 */
+	public function pseudonymize( string $value, string $field ): string
+	{
+		$salt      = $this->getSalt( $field );
+		$pseudonym = $this->generatePseudonym( $value, $salt );
+
+		if ( $this->storeMappings ) {
+			$this->storeMapping( $pseudonym, $value, $field );
+		}
+
+		return $pseudonym;
+	}
+
+	/**
+	 * Batch pseudonymize multiple values.
+	 *
+	 * @param array<string, mixed> $data
+	 * @param array<string>        $fields
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function batchPseudonymize( array $data, array $fields ): array
+	{
+		foreach ( $fields as $field ) {
+			if ( isset( $data[ $field ] ) && is_string( $data[ $field ] ) ) {
+				$data[ $field ] = $this->pseudonymize( $data[ $field ], $field );
+			}
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Batch de-pseudonymize multiple values.
+	 *
+	 * @param array<string, mixed> $data
+	 * @param array<string>        $fields
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function batchDePseudonymize( array $data, array $fields ): array
+	{
+		foreach ( $fields as $field ) {
+			if ( isset( $data[ $field ] ) && is_string( $data[ $field ] ) ) {
+				$original = $this->dePseudonymize( $data[ $field ], $field );
+				if ( null !== $original ) {
+					$data[ $field ] = $original;
+				}
+			}
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Generate a new mapping key.
+	 */
+	protected function generateMappingKey(): string
+	{
+		return Str::random( 32 );
+	}
+
+	/**
+	 * Get cache key for a mapping.
+	 */
+	protected function getMappingCacheKey( string $pseudonym, string $field ): string
+	{
+		return 'pseudonym_mapping:' . $field . ':' . $pseudonym;
+	}
+
+	/**
+	 * Get salt for a field.
+	 */
+	protected function getSalt( string $field ): string
+	{
+		// Combine app key with field and mapping key for consistent pseudonyms
+		return config( 'app.key' ) . $field . $this->currentMappingKey;
+	}
+
+	/**
+	 * Generate a consistent pseudonym for a value.
+	 *
+	 * Note: All algorithms must be deterministic to ensure the same input
+	 * always produces the same pseudonym. bcrypt is not supported as it
+	 * is non-deterministic by design.
+	 */
+	protected function generatePseudonym( string $value, string $salt ): string
+	{
+		$algorithm = config( 'artisanpack.compliance.compliance.minimization.anonymization_algorithm', 'sha256' );
+
+		return match ( $algorithm ) {
+			'sha256' => hash_hmac( 'sha256', $value, $salt ),
+			'sha384' => hash_hmac( 'sha384', $value, $salt ),
+			'sha512' => hash_hmac( 'sha512', $value, $salt ),
+			default  => hash_hmac( 'sha256', $value, $salt ),
+		};
+	}
+
+	/**
+	 * Store a pseudonym mapping.
+	 */
+	protected function storeMapping( string $pseudonym, string $value, string $field ): void
+	{
+		$cacheKey = $this->getMappingCacheKey( $pseudonym, $field );
+
+		// Store in local cache
+		$this->mappingCache[ $cacheKey ] = $value;
+
+		// Store in persistent cache (with no expiration by default)
+		Cache::put( $cacheKey, $value );
+
+		// Track this key in our index for later cleanup
+		$this->trackMappingKey( $cacheKey );
+	}
+
+	/**
+	 * Track a mapping key in the index for cleanup purposes.
+	 */
+	protected function trackMappingKey( string $cacheKey ): void
+	{
+		$trackedKeys = Cache::get( self::MAPPING_INDEX_KEY, [] );
+		$trackedKeys = is_array( $trackedKeys ) ? $trackedKeys : [];
+		$ttl         = config( 'artisanpack.compliance.compliance.minimization.mapping_ttl' );
+
+		if ( ! in_array( $cacheKey, $trackedKeys ) ) {
+			$trackedKeys[] = $cacheKey;
+			Cache::put( self::MAPPING_INDEX_KEY, $trackedKeys, $ttl );
+		}
+	}
+}

--- a/src/Compliance/Minimization/PseudonymizationEngine.php
+++ b/src/Compliance/Minimization/PseudonymizationEngine.php
@@ -204,7 +204,7 @@ class PseudonymizationEngine
 	 */
 	protected function generatePseudonym( string $value, string $salt ): string
 	{
-		$algorithm = config( 'artisanpack.compliance.compliance.minimization.anonymization_algorithm', 'sha256' );
+		$algorithm = config( 'artisanpack.compliance.minimization.anonymization_algorithm', 'sha256' );
 
 		return match ( $algorithm ) {
 			'sha256' => hash_hmac( 'sha256', $value, $salt ),
@@ -238,7 +238,7 @@ class PseudonymizationEngine
 	{
 		$trackedKeys = Cache::get( self::MAPPING_INDEX_KEY, [] );
 		$trackedKeys = is_array( $trackedKeys ) ? $trackedKeys : [];
-		$ttl         = config( 'artisanpack.compliance.compliance.minimization.mapping_ttl' );
+		$ttl         = config( 'artisanpack.compliance.minimization.mapping_ttl' );
 
 		if ( ! in_array( $cacheKey, $trackedKeys ) ) {
 			$trackedKeys[] = $cacheKey;

--- a/src/Compliance/Minimization/PseudonymizedResult.php
+++ b/src/Compliance/Minimization/PseudonymizedResult.php
@@ -1,0 +1,45 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Minimization;
+
+use Illuminate\Support\Collection;
+
+class PseudonymizedResult
+{
+    public function __construct(
+        public readonly Collection $data,
+        public readonly string $mappingKey,
+    ) {
+    }
+
+    /**
+     * Get the pseudonymized data.
+     */
+    public function getData(): Collection
+    {
+        return $this->data;
+    }
+
+    /**
+     * Get the mapping key for de-pseudonymization.
+     */
+    public function getMappingKey(): string
+    {
+        return $this->mappingKey;
+    }
+
+    /**
+     * Convert to array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'data'        => $this->data->toArray(),
+            'mapping_key' => $this->mappingKey,
+        ];
+    }
+}

--- a/src/Compliance/Models/PrivacyAwareModel.php
+++ b/src/Compliance/Models/PrivacyAwareModel.php
@@ -1,0 +1,204 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Models;
+
+use ArtisanPackUI\Compliance\Compliance\Traits\Auditable;
+use ArtisanPackUI\Compliance\Compliance\Traits\PrivacyByDesign;
+use Carbon\CarbonInterval;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+
+abstract class PrivacyAwareModel extends Model
+{
+    use Auditable;
+    use PrivacyByDesign;
+
+    /**
+     * Automatically log all data access.
+     */
+    protected static bool $logDataAccess = true;
+
+    /**
+     * Automatically encrypt sensitive fields.
+     */
+    protected static bool $autoEncryptSensitive = true;
+
+    /**
+     * Retention period in days (null = indefinite).
+     * Declared as static so scopes can access it properly.
+     */
+    protected static ?int $retentionDays = null;
+
+    /**
+     * Get lawful basis for processing.
+     */
+    public function getLawfulBasis(): string
+    {
+        return $this->lawfulBasis ?? 'consent';
+    }
+
+    /**
+     * Check if retention period has expired.
+     */
+    public function isRetentionExpired(): bool
+    {
+        if ( null === static::$retentionDays ) {
+            return false;
+        }
+
+        return $this->created_at->addDays( static::$retentionDays )->isPast();
+    }
+
+    /**
+     * Get time until retention expires.
+     */
+    public function getRetentionRemaining(): ?CarbonInterval
+    {
+        if ( null === static::$retentionDays ) {
+            return null;
+        }
+
+        $expiresAt = $this->created_at->addDays( static::$retentionDays );
+
+        if ( $expiresAt->isPast() ) {
+            return CarbonInterval::days( 0 );
+        }
+
+        return $expiresAt->diffAsCarbonInterval( now() );
+    }
+
+    /**
+     * Scope for data past retention period.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<static>  $query
+     * @param  int|null  $days  Optional explicit retention days to use
+     *
+     * @return \Illuminate\Database\Eloquent\Builder<static>
+     */
+    public function scopeExpiredRetention( $query, ?int $days = null )
+    {
+        $retentionDays = $days ?? static::$retentionDays;
+
+        if ( null === $retentionDays ) {
+            return $query->whereRaw( '1 = 0' ); // Return empty
+        }
+
+        return $query->where( 'created_at', '<', now()->subDays( $retentionDays ) );
+    }
+
+    /**
+     * Scope for data within retention period.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<static>  $query
+     * @param  int|null  $days  Optional explicit retention days to use
+     *
+     * @return \Illuminate\Database\Eloquent\Builder<static>
+     */
+    public function scopeWithinRetention( $query, ?int $days = null )
+    {
+        $retentionDays = $days ?? static::$retentionDays;
+
+        if ( null === $retentionDays ) {
+            return $query; // All records are within retention
+        }
+
+        return $query->where( 'created_at', '>=', now()->subDays( $retentionDays ) );
+    }
+
+    /**
+     * Get the audit trail for this record.
+     */
+    public function getAuditTrail(): Collection
+    {
+        // This would typically query an audit log table
+        // For now, returning empty collection
+        return collect();
+    }
+
+    /**
+     * Export all data for this record (for portability).
+     *
+     * @return array<string, mixed>
+     */
+    public function exportData(): array
+    {
+        $data = $this->toArray();
+
+        // Decrypt sensitive data for export
+        foreach ( $this->getSensitiveDataAttributes() as $attribute ) {
+            if ( isset( $data[ $attribute ] ) ) {
+                $decrypted = $this->decryptSensitiveAttribute( $attribute );
+                if ( null !== $decrypted ) {
+                    $data[ $attribute ] = $decrypted;
+                }
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Prepare data for deletion (for right to erasure).
+     *
+     * @return array<string, mixed>
+     */
+    public function prepareForDeletion(): array
+    {
+        return [
+            'model'          => static::class,
+            'id'             => $this->getKey(),
+            'personal_data'  => $this->getPersonalData(),
+            'sensitive_data' => array_keys( $this->getSensitiveData() ),
+            'created_at'     => $this->created_at?->toIso8601String(),
+        ];
+    }
+
+    /**
+     * Get the data category for this model.
+     */
+    public function getDataCategory(): string
+    {
+        return $this->dataCategory ?? 'general';
+    }
+
+    /**
+     * Get the data subject type (e.g., 'customer', 'employee').
+     */
+    public function getDataSubjectType(): string
+    {
+        return $this->dataSubjectType ?? 'user';
+    }
+
+    /**
+     * Boot the PrivacyAwareModel.
+     */
+    protected static function bootPrivacyAwareModel(): void
+    {
+        static::creating( function ( PrivacyAwareModel $model ): void {
+            if ( static::$autoEncryptSensitive ) {
+                $model->encryptSensitiveData();
+            }
+        } );
+
+        static::updating( function ( PrivacyAwareModel $model ): void {
+            if ( static::$autoEncryptSensitive ) {
+                // Only encrypt changed sensitive attributes
+                foreach ( $model->getSensitiveDataAttributes() as $attribute ) {
+                    if ( $model->isDirty( $attribute ) ) {
+                        $model->encryptSensitiveData();
+                        break;
+                    }
+                }
+            }
+        } );
+
+        static::retrieved( function ( PrivacyAwareModel $model ): void {
+            if ( static::$logDataAccess ) {
+                $accessor = auth()->id() ?? 'system';
+                $model->logDataAccess( (string) $accessor, 'retrieval' );
+            }
+        } );
+    }
+}

--- a/src/Compliance/Models/PrivacyAwareModel.php
+++ b/src/Compliance/Models/PrivacyAwareModel.php
@@ -48,7 +48,9 @@ abstract class PrivacyAwareModel extends Model
             return false;
         }
 
-        return $this->created_at->addDays( static::$retentionDays )->isPast();
+        // copy() before arithmetic so we don't mutate the model's
+        // created_at attribute and accidentally dirty it for save().
+        return $this->created_at->copy()->addDays( static::$retentionDays )->isPast();
     }
 
     /**
@@ -60,7 +62,7 @@ abstract class PrivacyAwareModel extends Model
             return null;
         }
 
-        $expiresAt = $this->created_at->addDays( static::$retentionDays );
+        $expiresAt = $this->created_at->copy()->addDays( static::$retentionDays );
 
         if ( $expiresAt->isPast() ) {
             return CarbonInterval::days( 0 );

--- a/src/Compliance/Monitoring/CheckResult.php
+++ b/src/Compliance/Monitoring/CheckResult.php
@@ -1,0 +1,121 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Monitoring;
+
+class CheckResult
+{
+    /**
+     * @param  array<string, mixed>  $details
+     * @param  array<string>  $violations
+     * @param  array<string>  $warnings
+     */
+    public function __construct(
+        public readonly string $status,
+        public readonly ?float $score = null,
+        public readonly int $itemsChecked = 0,
+        public readonly int $itemsCompliant = 0,
+        public readonly array $details = [],
+        public readonly array $violations = [],
+        public readonly array $warnings = [],
+    ) {
+    }
+
+    /**
+     * Create a passed result.
+     *
+     * @param  array<string, mixed>  $details
+     */
+    public static function passed( int $checked = 0, int $compliant = 0, array $details = [] ): self
+    {
+        return new self(
+            status: 'passed',
+            score: $checked > 0 ? ( $compliant / $checked ) * 100 : 100,
+            itemsChecked: $checked,
+            itemsCompliant: $compliant,
+            details: $details,
+        );
+    }
+
+    /**
+     * Create a failed result.
+     *
+     * @param  array<string>  $violations
+     * @param  array<string, mixed>  $details
+     */
+    public static function failed( array $violations, int $checked = 0, int $compliant = 0, array $details = [] ): self
+    {
+        return new self(
+            status: 'failed',
+            score: $checked > 0 ? ( $compliant / $checked ) * 100 : 0,
+            itemsChecked: $checked,
+            itemsCompliant: $compliant,
+            details: $details,
+            violations: $violations,
+        );
+    }
+
+    /**
+     * Create a warning result.
+     *
+     * @param  array<string>  $warnings
+     * @param  array<string, mixed>  $details
+     */
+    public static function warning( array $warnings, int $checked = 0, int $compliant = 0, array $details = [] ): self
+    {
+        return new self(
+            status: 'warning',
+            score: $checked > 0 ? ( $compliant / $checked ) * 100 : null,
+            itemsChecked: $checked,
+            itemsCompliant: $compliant,
+            details: $details,
+            warnings: $warnings,
+        );
+    }
+
+    /**
+     * Create an error result.
+     */
+    public static function error( string $message ): self
+    {
+        return new self(
+            status: 'error',
+            details: ['error' => $message],
+        );
+    }
+
+    /**
+     * Check if passed.
+     */
+    public function isPassed(): bool
+    {
+        return 'passed' === $this->status;
+    }
+
+    /**
+     * Check if failed.
+     */
+    public function isFailed(): bool
+    {
+        return 'failed' === $this->status;
+    }
+
+    /**
+     * Convert to array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'status'          => $this->status,
+            'score'           => $this->score,
+            'items_checked'   => $this->itemsChecked,
+            'items_compliant' => $this->itemsCompliant,
+            'details'         => $this->details,
+            'violations'      => $this->violations,
+            'warnings'        => $this->warnings,
+        ];
+    }
+}

--- a/src/Compliance/Monitoring/Checks/BaseComplianceCheck.php
+++ b/src/Compliance/Monitoring/Checks/BaseComplianceCheck.php
@@ -1,0 +1,156 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Monitoring\Checks;
+
+use ArtisanPackUI\Compliance\Compliance\Contracts\ComplianceCheckInterface;
+use ArtisanPackUI\Compliance\Compliance\Monitoring\CheckResult;
+use InvalidArgumentException;
+
+abstract class BaseComplianceCheck implements ComplianceCheckInterface
+{
+    protected string $name = '';
+
+    protected string $description = '';
+
+    protected string $category = 'general';
+
+    /**
+     * @var array<string>
+     */
+    protected array $regulations = ['gdpr'];
+
+    protected string $severity = 'medium';
+
+    protected string $schedule = '0 */6 * * *';
+
+    protected string $remediation = '';
+
+    protected bool $enabled = true;
+
+    /**
+     * Get check name.
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Get check description.
+     */
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    /**
+     * Get check category.
+     */
+    public function getCategory(): string
+    {
+        return $this->category;
+    }
+
+    /**
+     * Get applicable regulations.
+     *
+     * @return array<string>
+     */
+    public function getRegulations(): array
+    {
+        return $this->regulations;
+    }
+
+    /**
+     * Check if check is enabled.
+     *
+     * @throws InvalidArgumentException
+     */
+    public function isEnabled(): bool
+    {
+        $this->validateName();
+
+        $configKey = 'artisanpack.compliance.compliance.monitoring.checks.' . $this->name . '.enabled';
+
+        return config( $configKey, $this->enabled );
+    }
+
+    /**
+     * Get recommended schedule.
+     */
+    public function getRecommendedSchedule(): string
+    {
+        return $this->schedule;
+    }
+
+    /**
+     * Get severity.
+     *
+     * @throws InvalidArgumentException
+     */
+    public function getSeverity(): string
+    {
+        $this->validateName();
+
+        return config(
+            'artisanpack.compliance.compliance.monitoring.checks.' . $this->name . '.severity',
+            $this->severity,
+        );
+    }
+
+    /**
+     * Get remediation guidance.
+     */
+    public function getRemediation(): string
+    {
+        return $this->remediation;
+    }
+
+    /**
+     * Validate that the check name is non-empty.
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function validateName(): void
+    {
+        if ( empty( $this->name ) ) {
+            throw new InvalidArgumentException(
+                'Compliance check name cannot be empty. Ensure the $name property is set in the concrete check class.',
+            );
+        }
+    }
+
+    /**
+     * Create a passed result.
+     *
+     * @param  array<string, mixed>  $details
+     */
+    protected function passed( int $checked = 0, int $compliant = 0, array $details = [] ): CheckResult
+    {
+        return CheckResult::passed( $checked, $compliant, $details );
+    }
+
+    /**
+     * Create a failed result.
+     *
+     * @param  array<string>  $violations
+     * @param  array<string, mixed>  $details
+     */
+    protected function failed( array $violations, int $checked = 0, int $compliant = 0, array $details = [] ): CheckResult
+    {
+        return CheckResult::failed( $violations, $checked, $compliant, $details );
+    }
+
+    /**
+     * Create a warning result.
+     *
+     * @param  array<string>  $warnings
+     * @param  array<string, mixed>  $details
+     */
+    protected function warning( array $warnings, int $checked = 0, int $compliant = 0, array $details = [] ): CheckResult
+    {
+        return CheckResult::warning( $warnings, $checked, $compliant, $details );
+    }
+}

--- a/src/Compliance/Monitoring/Checks/BaseComplianceCheck.php
+++ b/src/Compliance/Monitoring/Checks/BaseComplianceCheck.php
@@ -72,7 +72,7 @@ abstract class BaseComplianceCheck implements ComplianceCheckInterface
     {
         $this->validateName();
 
-        $configKey = 'artisanpack.compliance.compliance.monitoring.checks.' . $this->name . '.enabled';
+        $configKey = 'artisanpack.compliance.monitoring.checks.' . $this->name . '.enabled';
 
         return config( $configKey, $this->enabled );
     }
@@ -95,7 +95,7 @@ abstract class BaseComplianceCheck implements ComplianceCheckInterface
         $this->validateName();
 
         return config(
-            'artisanpack.compliance.compliance.monitoring.checks.' . $this->name . '.severity',
+            'artisanpack.compliance.monitoring.checks.' . $this->name . '.severity',
             $this->severity,
         );
     }

--- a/src/Compliance/Monitoring/Checks/ConsentValidityCheck.php
+++ b/src/Compliance/Monitoring/Checks/ConsentValidityCheck.php
@@ -1,0 +1,81 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Monitoring\Checks;
+
+use ArtisanPackUI\Compliance\Compliance\Monitoring\CheckResult;
+use ArtisanPackUI\Compliance\Models\ConsentPolicy;
+use ArtisanPackUI\Compliance\Models\ConsentRecord;
+
+class ConsentValidityCheck extends BaseComplianceCheck
+{
+    protected string $name = 'consent_validity';
+
+    protected string $description = 'Validates that all consent records are properly linked to active policies';
+
+    protected string $category = 'consent';
+
+    protected array $regulations = ['gdpr', 'ccpa', 'lgpd'];
+
+    protected string $severity = 'high';
+
+    protected string $remediation = 'Review consent records and ensure all are linked to valid, active consent policies. Request reconsent where necessary.';
+
+    /**
+     * Run the check.
+     */
+    public function run(): CheckResult
+    {
+        $violations = [];
+        $warnings   = [];
+
+        // Eager-load the related policy so we don't hit the DB once per
+        // consent record inside the loop (N+1).
+        $consents  = ConsentRecord::where( 'status', 'granted' )->with( 'policy' )->get();
+        $checked   = $consents->count();
+        $compliant = 0;
+
+        foreach ( $consents as $consent ) {
+            $policy = $consent->policy;
+
+            if ( ! $policy ) {
+                $violations[] = "Consent record {$consent->id} references non-existent policy";
+
+                continue;
+            }
+
+            $hasWarning = false;
+
+            if ( ! $policy->is_active ) {
+                $warnings[] = "Consent record {$consent->id} references inactive policy";
+                $hasWarning = true;
+            }
+
+            // Check if policy version matches
+            $latestPolicy = ConsentPolicy::getLatestForPurpose( $consent->purpose );
+            if ( $latestPolicy && $consent->policy_version !== $latestPolicy->version ) {
+                $warnings[] = "Consent record {$consent->id} uses outdated policy version {$consent->policy_version}";
+                $hasWarning = true;
+            }
+
+            // Only count records with no violations or warnings as compliant —
+            // outdated-version / inactive-policy records still need follow-up.
+            if ( ! $hasWarning ) {
+                $compliant++;
+            }
+        }
+
+        if ( ! empty( $violations ) ) {
+            return $this->failed( $violations, $checked, $compliant, [
+                'warnings' => $warnings,
+            ] );
+        }
+
+        if ( ! empty( $warnings ) ) {
+            return $this->warning( $warnings, $checked, $compliant );
+        }
+
+        return $this->passed( $checked, $compliant );
+    }
+}

--- a/src/Compliance/Monitoring/Checks/DpiaCompletionCheck.php
+++ b/src/Compliance/Monitoring/Checks/DpiaCompletionCheck.php
@@ -1,0 +1,95 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Monitoring\Checks;
+
+use ArtisanPackUI\Compliance\Compliance\Monitoring\CheckResult;
+use ArtisanPackUI\Compliance\Models\DataProtectionAssessment;
+use ArtisanPackUI\Compliance\Models\ProcessingActivity;
+
+class DpiaCompletionCheck extends BaseComplianceCheck
+{
+    protected string $name = 'dpia_completion';
+
+    protected string $description = 'Checks that DPIAs are completed for high-risk processing activities';
+
+    protected string $category = 'assessment';
+
+    protected array $regulations = ['gdpr'];
+
+    protected string $severity = 'medium';
+
+    protected string $remediation = 'Complete DPIA for all processing activities marked as requiring assessment. Ensure DPIAs are reviewed annually.';
+
+    /**
+     * Run the check.
+     */
+    public function run(): CheckResult
+    {
+        $violations = [];
+        $warnings   = [];
+
+        // Get activities requiring DPIA
+        $activitiesRequiringDpia = ProcessingActivity::active()
+            ->requiresDpia()
+            ->get();
+
+        $checked   = $activitiesRequiringDpia->count();
+        $compliant = 0;
+
+        foreach ( $activitiesRequiringDpia as $activity ) {
+            // Check if DPIA exists
+            $dpia = DataProtectionAssessment::where( 'processing_activity_id', $activity->id )
+                ->approved()
+                ->orderByDesc( 'version' )
+                ->first();
+
+            if ( ! $dpia ) {
+                $violations[] = "Processing activity '{$activity->name}' requires DPIA but none exists";
+
+                continue;
+            }
+
+            // Check if DPIA is due for review
+            if ( $dpia->next_review_at && $dpia->next_review_at->isPast() ) {
+                $warnings[] = "DPIA for '{$activity->name}' is overdue for review";
+            }
+
+            // Check for unaddressed high risks
+            $highRisks = $dpia->risks()
+                ->highRisk()
+                ->whereNotIn( 'status', ['mitigated', 'accepted'] )
+                ->count();
+
+            if ( $highRisks > 0 ) {
+                $warnings[] = "DPIA for '{$activity->name}' has {$highRisks} unaddressed high/critical risks";
+            }
+
+            $compliant++;
+        }
+
+        // Also check for DPIAs without linked activities
+        $orphanDpias = DataProtectionAssessment::whereNull( 'processing_activity_id' )->count();
+        if ( $orphanDpias > 0 ) {
+            $warnings[] = "{$orphanDpias} DPIA(s) not linked to processing activities";
+        }
+
+        $details = [
+            'activities_requiring_dpia' => $checked,
+            'dpia_reviews_due'          => DataProtectionAssessment::approved()
+                ->where( 'next_review_at', '<=', now() )
+                ->count(),
+        ];
+
+        if ( ! empty( $violations ) ) {
+            return $this->failed( $violations, $checked, $compliant, array_merge( $details, ['warnings' => $warnings] ) );
+        }
+
+        if ( ! empty( $warnings ) ) {
+            return $this->warning( $warnings, $checked, $compliant, $details );
+        }
+
+        return $this->passed( $checked, $compliant, $details );
+    }
+}

--- a/src/Compliance/Monitoring/Checks/DsrTimelinessCheck.php
+++ b/src/Compliance/Monitoring/Checks/DsrTimelinessCheck.php
@@ -1,0 +1,70 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Monitoring\Checks;
+
+use ArtisanPackUI\Compliance\Compliance\Monitoring\CheckResult;
+use ArtisanPackUI\Compliance\Models\ErasureRequest;
+use ArtisanPackUI\Compliance\Models\PortabilityRequest;
+
+class DsrTimelinessCheck extends BaseComplianceCheck
+{
+    protected string $name = 'dsr_timeliness';
+
+    protected string $description = 'Checks that Data Subject Requests are processed within legal deadlines';
+
+    protected string $category = 'data_subject_rights';
+
+    protected array $regulations = ['gdpr', 'ccpa', 'lgpd'];
+
+    protected string $severity = 'critical';
+
+    protected string $remediation = 'Process overdue requests immediately. Review and optimize request handling procedures to prevent future delays.';
+
+    /**
+     * Run the check.
+     */
+    public function run(): CheckResult
+    {
+        $violations = [];
+
+        // Check erasure requests
+        $overdueErasure = ErasureRequest::overdue()->get();
+        foreach ( $overdueErasure as $request ) {
+            $daysOverdue  = $request->deadline_at->diffInDays( now() );
+            $violations[] = "Erasure request {$request->request_number} is {$daysOverdue} days overdue";
+        }
+
+        // Check portability requests
+        $overduePortability = PortabilityRequest::pending()
+            ->where( 'deadline_at', '<', now() )
+            ->get();
+        foreach ( $overduePortability as $request ) {
+            $daysOverdue  = $request->deadline_at->diffInDays( now() );
+            $violations[] = "Portability request {$request->request_number} is {$daysOverdue} days overdue";
+        }
+
+        // Calculate statistics
+        $totalErasure     = ErasureRequest::pending()->count();
+        $totalPortability = PortabilityRequest::pending()->count();
+        $totalPending     = $totalErasure + $totalPortability;
+        $totalOverdue     = count( $violations );
+
+        $checked   = $totalPending;
+        $compliant = $totalPending - $totalOverdue;
+
+        $details = [
+            'pending_erasure_requests'     => $totalErasure,
+            'pending_portability_requests' => $totalPortability,
+            'overdue_erasure'              => $overdueErasure->count(),
+            'overdue_portability'          => $overduePortability->count(),
+        ];
+
+        if ( ! empty( $violations ) ) {
+            return $this->failed( $violations, $checked, $compliant, $details );
+        }
+
+        return $this->passed( $checked, $compliant, $details );
+    }
+}

--- a/src/Compliance/Monitoring/Checks/RetentionPolicyCheck.php
+++ b/src/Compliance/Monitoring/Checks/RetentionPolicyCheck.php
@@ -1,0 +1,104 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Monitoring\Checks;
+
+use ArtisanPackUI\Compliance\Compliance\Monitoring\CheckResult;
+use ArtisanPackUI\Compliance\Models\RetentionPolicy;
+use Exception;
+use Illuminate\Support\Facades\DB;
+
+class RetentionPolicyCheck extends BaseComplianceCheck
+{
+    protected string $name = 'retention_policy';
+
+    protected string $description = 'Checks that data retention policies are defined and enforced';
+
+    protected string $category = 'data_minimization';
+
+    protected array $regulations = ['gdpr', 'ccpa'];
+
+    protected string $severity = 'medium';
+
+    protected string $remediation = 'Define retention policies for all data categories. Implement automated purging of expired data.';
+
+    /**
+     * Run the check.
+     */
+    public function run(): CheckResult
+    {
+        $violations = [];
+        $warnings   = [];
+
+        // Check for active retention policies
+        $policies = RetentionPolicy::active()->get();
+
+        if ( $policies->isEmpty() ) {
+            $violations[] = 'No retention policies defined';
+
+            return $this->failed( $violations, 1, 0 );
+        }
+
+        $checked   = $policies->count();
+        $compliant = 0;
+
+        foreach ( $policies as $policy ) {
+            // Check if policy has model class
+            if ( empty( $policy->model_class ) ) {
+                $warnings[] = "Policy '{$policy->name}' has no associated model class";
+
+                continue;
+            }
+
+            // Check if model class exists
+            if ( ! class_exists( $policy->model_class ) ) {
+                $violations[] = "Policy '{$policy->name}' references non-existent model class";
+
+                continue;
+            }
+
+            // Verify the configured class is actually an Eloquent model
+            // before instantiating it. The value comes from the database,
+            // so a misconfigured policy could otherwise instantiate
+            // arbitrary classes here.
+            if ( ! is_subclass_of( $policy->model_class, \Illuminate\Database\Eloquent\Model::class ) ) {
+                $violations[] = "Policy '{$policy->name}' model class is not an Eloquent model";
+
+                continue;
+            }
+
+            // Check for data exceeding retention
+            if ( null !== $policy->retention_days ) {
+                try {
+                    $expiredCount = DB::table( (new $policy->model_class)->getTable() )
+                        ->where( 'created_at', '<', now()->subDays( $policy->retention_days ) )
+                        ->count();
+
+                    if ( $expiredCount > 0 ) {
+                        $warnings[] = "Policy '{$policy->name}': {$expiredCount} records exceed retention period";
+                    }
+                } catch ( Exception $e ) {
+                    $warnings[] = "Could not check policy '{$policy->name}': " . $e->getMessage();
+                }
+            }
+
+            $compliant++;
+        }
+
+        $details = [
+            'total_policies'   => $checked,
+            'policies_checked' => array_map( fn ( $p ) => $p->name, $policies->all() ),
+        ];
+
+        if ( ! empty( $violations ) ) {
+            return $this->failed( $violations, $checked, $compliant, array_merge( $details, ['warnings' => $warnings] ) );
+        }
+
+        if ( ! empty( $warnings ) ) {
+            return $this->warning( $warnings, $checked, $compliant, $details );
+        }
+
+        return $this->passed( $checked, $compliant, $details );
+    }
+}

--- a/src/Compliance/Monitoring/ComplianceMonitor.php
+++ b/src/Compliance/Monitoring/ComplianceMonitor.php
@@ -1,0 +1,348 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Monitoring;
+
+use ArtisanPackUI\Compliance\Compliance\Contracts\ComplianceCheckInterface;
+use ArtisanPackUI\Compliance\Events\ComplianceCheckCompleted;
+use ArtisanPackUI\Compliance\Events\ComplianceViolationDetected;
+use ArtisanPackUI\Compliance\Models\ComplianceCheckResult;
+use ArtisanPackUI\Compliance\Models\ComplianceScore;
+use ArtisanPackUI\Compliance\Models\ComplianceViolation;
+use Exception;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class ComplianceMonitor
+{
+    /**
+     * @var array<string, ComplianceCheckInterface>
+     */
+    protected array $checks = [];
+
+    /**
+     * Register a compliance check.
+     */
+    public function registerCheck( ComplianceCheckInterface $check ): void
+    {
+        $this->checks[ $check->getName() ] = $check;
+    }
+
+    /**
+     * Get all registered checks.
+     *
+     * @return array<string, ComplianceCheckInterface>
+     */
+    public function getChecks(): array
+    {
+        return $this->checks;
+    }
+
+    /**
+     * Run a specific check.
+     */
+    public function runCheck( string $checkName ): ?ComplianceCheckResult
+    {
+        if ( ! isset( $this->checks[ $checkName ] ) ) {
+            return null;
+        }
+
+        $check = $this->checks[ $checkName ];
+
+        if ( ! $check->isEnabled() ) {
+            return null;
+        }
+
+        $startTime = microtime( true );
+
+        try {
+            $result        = $check->run();
+            $executionTime = (int) ( ( microtime( true ) - $startTime ) * 1000 );
+
+            // Wrap result and violation creation in a transaction
+            $storedResult = DB::transaction( function () use ( $checkName, $result, $executionTime, $check ) {
+                // Store result
+                $storedResult = ComplianceCheckResult::create( [
+                    'check_name'        => $checkName,
+                    'status'            => $result->status,
+                    'score'             => $result->score,
+                    'violations_found'  => count( $result->violations ),
+                    'warnings_found'    => count( $result->warnings ),
+                    'items_checked'     => $result->itemsChecked,
+                    'items_compliant'   => $result->itemsCompliant,
+                    'details'           => $result->details,
+                    'execution_time_ms' => $executionTime,
+                ] );
+
+                // Create violations if any
+                if ( ! empty( $result->violations ) ) {
+                    $this->createViolations( $check, $result->violations );
+                }
+
+                return $storedResult;
+            } );
+
+            // Fire event only after transaction commits successfully
+            event( new ComplianceCheckCompleted( $storedResult ) );
+
+            return $storedResult;
+        } catch ( Exception $e ) {
+            Log::error( "Compliance check {$checkName} failed", [
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ] );
+
+            return ComplianceCheckResult::create( [
+                'check_name'        => $checkName,
+                'status'            => 'error',
+                'score'             => null,
+                'violations_found'  => 0,
+                'warnings_found'    => 0,
+                'items_checked'     => 0,
+                'items_compliant'   => 0,
+                'details'           => ['error' => $e->getMessage()],
+                'execution_time_ms' => (int) ( ( microtime( true ) - $startTime ) * 1000 ),
+            ] );
+        }
+    }
+
+    /**
+     * Run all enabled checks.
+     *
+     * @return Collection<string, ComplianceCheckResult>
+     */
+    public function runAllChecks(): Collection
+    {
+        $results = collect();
+
+        foreach ( $this->checks as $name => $check ) {
+            if ( $check->isEnabled() ) {
+                $result = $this->runCheck( $name );
+                if ( $result ) {
+                    $results->put( $name, $result );
+                }
+            }
+        }
+
+        // Calculate overall score
+        $this->calculateOverallScore( $results );
+
+        return $results;
+    }
+
+    /**
+     * Run checks by category.
+     *
+     * @return Collection<string, ComplianceCheckResult>
+     */
+    public function runChecksByCategory( string $category ): Collection
+    {
+        $results = collect();
+
+        foreach ( $this->checks as $name => $check ) {
+            if ( $check->isEnabled() && $check->getCategory() === $category ) {
+                $result = $this->runCheck( $name );
+                if ( $result ) {
+                    $results->put( $name, $result );
+                }
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * Get latest results for all checks.
+     *
+     * @return Collection<string, ComplianceCheckResult|null>
+     */
+    public function getLatestResults(): Collection
+    {
+        $results = collect();
+
+        foreach ( $this->checks as $name => $check ) {
+            $result = ComplianceCheckResult::getLatestForCheck( $name );
+            $results->put( $name, $result );
+        }
+
+        return $results;
+    }
+
+    /**
+     * Get check history.
+     */
+    public function getCheckHistory( string $checkName, int $limit = 30 ): Collection
+    {
+        return ComplianceCheckResult::forCheck( $checkName )
+            ->orderByDesc( 'created_at' )
+            ->limit( $limit )
+            ->get();
+    }
+
+    /**
+     * Get open violations.
+     */
+    public function getOpenViolations(): Collection
+    {
+        return ComplianceViolation::open()->orderByDesc( 'created_at' )->get();
+    }
+
+    /**
+     * Get violations by severity.
+     *
+     * @return Collection<string, Collection<int, ComplianceViolation>>
+     */
+    public function getViolationsBySeverity(): Collection
+    {
+        return ComplianceViolation::open()
+            ->orderByDesc( 'created_at' )
+            ->get()
+            ->groupBy( 'severity' );
+    }
+
+    /**
+     * Get the current compliance score.
+     */
+    public function getCurrentScore(): ?ComplianceScore
+    {
+        return ComplianceScore::getLatest();
+    }
+
+    /**
+     * Get compliance trend.
+     *
+     * @return Collection<int, ComplianceScore>
+     */
+    public function getScoreTrend( int $days = 30 ): Collection
+    {
+        return ComplianceScore::getHistory( null, $days );
+    }
+
+    /**
+     * Get compliance status summary.
+     *
+     * @return array<string, mixed>
+     */
+    public function getStatusSummary(): array
+    {
+        $latestResults = $this->getLatestResults();
+        $violations    = $this->getViolationsBySeverity();
+        $score         = $this->getCurrentScore();
+
+        return [
+            'score'  => $score?->overall_score ?? 0,
+            'grade'  => $score?->getGrade() ?? 'N/A',
+            'checks' => [
+                'total'   => count( $this->checks ),
+                'passed'  => $latestResults->filter( fn ( $r ) => $r?->isPassed() )->count(),
+                'failed'  => $latestResults->filter( fn ( $r ) => $r?->isFailed() )->count(),
+                'pending' => $latestResults->filter( fn ( $r ) => null === $r )->count(),
+            ],
+            'violations' => [
+                'total'    => ComplianceViolation::open()->count(),
+                'critical' => $violations->get( 'critical', collect() )->count(),
+                'high'     => $violations->get( 'high', collect() )->count(),
+                'medium'   => $violations->get( 'medium', collect() )->count(),
+                'low'      => $violations->get( 'low', collect() )->count(),
+            ],
+            'last_check_at' => $latestResults->max( fn ( $r ) => $r?->created_at )?->toIso8601String(),
+        ];
+    }
+
+    /**
+     * Calculate and store overall compliance score.
+     *
+     * @param  Collection<string, ComplianceCheckResult>  $results
+     */
+    protected function calculateOverallScore( Collection $results ): ComplianceScore
+    {
+        $categoryScores = [];
+        $totalScore     = 0;
+        $checkCount     = 0;
+
+        // Calculate scores by category
+        $byCategory = $results->groupBy( function ( $result ) {
+            return $this->checks[ $result->check_name ]?->getCategory() ?? 'general';
+        } );
+
+        foreach ( $byCategory as $category => $categoryResults ) {
+            $scores = $categoryResults->pluck( 'score' )->filter()->values();
+            if ( $scores->isNotEmpty() ) {
+                $categoryScores[ $category ] = $scores->avg();
+                $totalScore += $categoryScores[ $category ];
+                $checkCount++;
+            }
+        }
+
+        $overallScore = $checkCount > 0 ? $totalScore / $checkCount : 0;
+
+        // Generate findings and recommendations
+        $findings        = [];
+        $recommendations = [];
+
+        foreach ( $results as $result ) {
+            if ( 'failed' === $result->status ) {
+                $check      = $this->checks[ $result->check_name ] ?? null;
+                $findings[] = [
+                    'check'      => $result->check_name,
+                    'severity'   => $check?->getSeverity() ?? 'medium',
+                    'violations' => $result->violations_found,
+                ];
+                if ( $check ) {
+                    $recommendations[] = $check->getRemediation();
+                }
+            }
+        }
+
+        return ComplianceScore::create( [
+            'overall_score'   => round( $overallScore, 2 ),
+            'regulation'      => 'all',
+            'category_scores' => $categoryScores,
+            'findings'        => $findings,
+            'recommendations' => array_unique( $recommendations ),
+            'calculated_at'   => now(),
+            'calculated_by'   => 'system',
+        ] );
+    }
+
+    /**
+     * Create violations from check results.
+     *
+     * Checks for existing open violations to prevent duplicates.
+     *
+     * @param  array<string>  $violations
+     */
+    protected function createViolations( ComplianceCheckInterface $check, array $violations ): void
+    {
+        foreach ( $violations as $violation ) {
+            // Check for existing open violation with same check_name and title
+            $existing = ComplianceViolation::where( 'check_name', $check->getName() )
+                ->where( 'title', $violation )
+                ->where( 'status', 'open' )
+                ->first();
+
+            if ( $existing ) {
+                // Update the existing violation's timestamp to show it's still occurring
+                $existing->touch();
+
+                continue;
+            }
+
+            // Create new violation only if no matching open violation exists
+            $created = ComplianceViolation::create( [
+                'check_name'        => $check->getName(),
+                'category'          => $check->getCategory(),
+                'regulation'        => implode( ',', $check->getRegulations() ),
+                'severity'          => $check->getSeverity(),
+                'title'             => $violation,
+                'description'       => $check->getDescription(),
+                'remediation_steps' => [$check->getRemediation()],
+                'status'            => 'open',
+            ] );
+
+            event( new ComplianceViolationDetected( $created));
+        }
+    }
+}

--- a/src/Compliance/Portability/DataPackager.php
+++ b/src/Compliance/Portability/DataPackager.php
@@ -1,0 +1,104 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Portability;
+
+use ArtisanPackUI\Compliance\Compliance\Portability\Formatters\CsvFormatter;
+use ArtisanPackUI\Compliance\Compliance\Portability\Formatters\JsonFormatter;
+use ArtisanPackUI\Compliance\Compliance\Portability\Formatters\XmlFormatter;
+use InvalidArgumentException;
+
+class DataPackager
+{
+    protected JsonFormatter $jsonFormatter;
+
+    protected XmlFormatter $xmlFormatter;
+
+    protected CsvFormatter $csvFormatter;
+
+    public function __construct(
+        JsonFormatter $jsonFormatter,
+        XmlFormatter $xmlFormatter,
+        CsvFormatter $csvFormatter,
+    ) {
+        $this->jsonFormatter = $jsonFormatter;
+        $this->xmlFormatter  = $xmlFormatter;
+        $this->csvFormatter  = $csvFormatter;
+    }
+
+    /**
+     * Package data for export.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function package( array $data, string $format, int $userId ): ExportPackage
+    {
+        $content = match ( $format ) {
+            'json'  => $this->jsonFormatter->format( $data ),
+            'xml'   => $this->xmlFormatter->format( $data ),
+            'csv'   => $this->csvFormatter->format( $data ),
+            default => throw new InvalidArgumentException( "Unsupported format: {$format}" ),
+        };
+
+        $extension = match ( $format ) {
+            'csv'   => 'zip', // CsvFormatter produces a ZIP archive
+            default => $format,
+        };
+
+        return new ExportPackage(
+            content: $content,
+            format: $format,
+            extension: $extension,
+            hash: hash( 'sha256', $content ),
+            size: strlen( $content ),
+            userId: $userId,
+        );
+    }
+
+    /**
+     * Validate export schema compatibility.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function validateSchema( array $data, string $format ): bool
+    {
+        // Basic validation - can be extended with JSON Schema, XSD, etc.
+        return match ( $format ) {
+            'json'  => $this->validateJsonSchema( $data ),
+            'xml'   => $this->validateXmlSchema( $data ),
+            'csv'   => $this->validateCsvSchema( $data ),
+            default => false,
+        };
+    }
+
+    /**
+     * Validate JSON schema.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    protected function validateJsonSchema( array $data ): bool
+    {
+        return isset( $data['export_info'] ) && isset( $data['data'] );
+    }
+
+    /**
+     * Validate XML schema.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    protected function validateXmlSchema( array $data ): bool
+    {
+        return isset( $data['export_info'] ) && isset( $data['data'] );
+    }
+
+    /**
+     * Validate CSV schema.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    protected function validateCsvSchema( array $data ): bool
+    {
+        return isset( $data['data'] );
+    }
+}

--- a/src/Compliance/Portability/ExportPackage.php
+++ b/src/Compliance/Portability/ExportPackage.php
@@ -1,0 +1,74 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Portability;
+
+class ExportPackage
+{
+    public function __construct(
+        protected string $content,
+        protected string $format,
+        protected string $extension,
+        protected string $hash,
+        protected int $size,
+        protected ?int $userId = null,
+    ) {
+    }
+
+    /**
+     * Get the package content.
+     */
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    /**
+     * Get the format.
+     */
+    public function getFormat(): string
+    {
+        return $this->format;
+    }
+
+    /**
+     * Get the file extension.
+     */
+    public function getExtension(): string
+    {
+        return $this->extension;
+    }
+
+    /**
+     * Get the content hash.
+     */
+    public function getHash(): string
+    {
+        return $this->hash;
+    }
+
+    /**
+     * Get the content size.
+     */
+    public function getSize(): int
+    {
+        return $this->size;
+    }
+
+    /**
+     * Verify content integrity.
+     */
+    public function verify(): bool
+    {
+        return hash_equals( $this->hash, hash( 'sha256', $this->content ) );
+    }
+
+    /**
+     * Get the user ID who requested the export.
+     */
+    public function getUserId(): ?int
+    {
+        return $this->userId;
+    }
+}

--- a/src/Compliance/Portability/Exporters/BaseExporter.php
+++ b/src/Compliance/Portability/Exporters/BaseExporter.php
@@ -1,0 +1,77 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Portability\Exporters;
+
+use ArtisanPackUI\Compliance\Compliance\Contracts\DataExporterInterface;
+use Illuminate\Support\Collection;
+
+abstract class BaseExporter implements DataExporterInterface
+{
+    /**
+     * Data category.
+     */
+    protected string $category = 'general';
+
+    /**
+     * Supported formats.
+     *
+     * @var array<string>
+     */
+    protected array $supportedFormats = ['json', 'xml', 'csv'];
+
+    /**
+     * Get data category.
+     */
+    public function getCategory(): string
+    {
+        return $this->category;
+    }
+
+    /**
+     * Get supported formats.
+     *
+     * @return array<string>
+     */
+    public function getSupportedFormats(): array
+    {
+        return $this->supportedFormats;
+    }
+
+    /**
+     * Transform data for export.
+     *
+     * @return array<string, mixed>
+     */
+    public function transform( Collection $data ): array
+    {
+        return $data->map( fn ( $item ) => $this->transformItem( $item ) )->toArray();
+    }
+
+    /**
+     * Get record count for user.
+     */
+    public function getRecordCount( int $userId ): int
+    {
+        return $this->getData( $userId )->count();
+    }
+
+    /**
+     * Transform a single item.
+     *
+     * @return array<string, mixed>
+     */
+    protected function transformItem( mixed $item ): array
+    {
+        if ( is_array( $item ) ) {
+            return $item;
+        }
+
+        if ( method_exists( $item, 'toArray' ) ) {
+            return $item->toArray();
+        }
+
+        return (array) $item;
+    }
+}

--- a/src/Compliance/Portability/Exporters/ConsentDataExporter.php
+++ b/src/Compliance/Portability/Exporters/ConsentDataExporter.php
@@ -1,0 +1,72 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Portability\Exporters;
+
+use ArtisanPackUI\Compliance\Models\ConsentRecord;
+use Illuminate\Support\Collection;
+
+class ConsentDataExporter extends BaseExporter
+{
+    protected string $category = 'consent';
+
+    /**
+     * Get exporter name.
+     */
+    public function getName(): string
+    {
+        return 'consent_records';
+    }
+
+    /**
+     * Get exportable data for user.
+     */
+    public function getData( int $userId ): Collection
+    {
+        return ConsentRecord::where( 'user_id', $userId )->get();
+    }
+
+    /**
+     * Get data schema.
+     *
+     * @return array<string, mixed>
+     */
+    public function getSchema(): array
+    {
+        return [
+            'type'       => 'object',
+            'properties' => [
+                'purpose'           => ['type' => 'string', 'description' => 'Consent purpose'],
+                'policy_version'    => ['type' => 'string', 'description' => 'Policy version'],
+                'status'            => ['type' => 'string', 'enum' => ['granted', 'withdrawn', 'expired']],
+                'consent_type'      => ['type' => 'string', 'enum' => ['explicit', 'implied']],
+                'collection_method' => ['type' => 'string', 'description' => 'How consent was collected'],
+                'granular_choices'  => ['type' => 'object', 'description' => 'Granular consent choices', 'nullable' => true],
+                'granted_at'        => ['type' => 'string', 'format' => 'date-time'],
+                'withdrawn_at'      => ['type' => 'string', 'format' => 'date-time', 'nullable' => true],
+                'expires_at'        => ['type' => 'string', 'format' => 'date-time', 'nullable' => true],
+            ],
+        ];
+    }
+
+    /**
+     * Transform a single item.
+     *
+     * @return array<string, mixed>
+     */
+    protected function transformItem( mixed $item ): array
+    {
+        return [
+            'purpose'           => $item->purpose,
+            'policy_version'    => $item->policy_version,
+            'status'            => $item->status,
+            'consent_type'      => $item->consent_type,
+            'collection_method' => $item->collection_method,
+            'granular_choices'  => $item->granular_choices,
+            'granted_at'        => $item->created_at?->toIso8601String(),
+            'withdrawn_at'      => $item->withdrawn_at?->toIso8601String(),
+            'expires_at'        => $item->expires_at?->toIso8601String(),
+        ];
+    }
+}

--- a/src/Compliance/Portability/Exporters/UserDataExporter.php
+++ b/src/Compliance/Portability/Exporters/UserDataExporter.php
@@ -1,0 +1,81 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Portability\Exporters;
+
+use Illuminate\Support\Collection;
+
+class UserDataExporter extends BaseExporter
+{
+    protected string $category = 'profile';
+
+    /**
+     * Get exporter name.
+     */
+    public function getName(): string
+    {
+        return 'user_profile';
+    }
+
+    /**
+     * Get exportable data for user.
+     */
+    public function getData( int $userId ): Collection
+    {
+        $userModel = config( 'auth.providers.users.model' );
+
+        // Bail gracefully if the auth provider is misconfigured rather
+        // than fatal-erroring on `null::find()`.
+        if ( ! is_string( $userModel ) || '' === $userModel || ! class_exists( $userModel ) ) {
+            return collect();
+        }
+
+        $user = $userModel::find( $userId );
+
+        if ( ! $user ) {
+            return collect();
+        }
+
+        return collect( [$user] );
+    }
+
+    /**
+     * Get data schema.
+     *
+     * @return array<string, mixed>
+     */
+    public function getSchema(): array
+    {
+        return [
+            'type'       => 'object',
+            'properties' => [
+                'id'                => ['type' => 'integer', 'description' => 'User ID'],
+                'name'              => ['type' => 'string', 'description' => 'Full name'],
+                'email'             => ['type' => 'string', 'format' => 'email', 'description' => 'Email address'],
+                'email_verified_at' => ['type' => 'string', 'format' => 'date-time', 'description' => 'Email verification date'],
+                'created_at'        => ['type' => 'string', 'format' => 'date-time', 'description' => 'Account creation date'],
+                'updated_at'        => ['type' => 'string', 'format' => 'date-time', 'description' => 'Last update date'],
+            ],
+        ];
+    }
+
+    /**
+     * Transform a single item.
+     *
+     * @return array<string, mixed>
+     */
+    protected function transformItem( mixed $item ): array
+    {
+        $data = parent::transformItem( $item );
+
+        // Allow-list export: only fields declared in getSchema()['properties']
+        // ship to the user. A deny-list would silently leak any future
+        // sensitive column added upstream (api_token, two_factor_secret,
+        // recovery codes, etc.) which is a worse default for a privacy /
+        // compliance package.
+        $allowedFields = array_keys( $this->getSchema()['properties'] ?? [] );
+
+        return array_intersect_key( $data, array_flip( $allowedFields ) );
+    }
+}

--- a/src/Compliance/Portability/Formatters/CsvFormatter.php
+++ b/src/Compliance/Portability/Formatters/CsvFormatter.php
@@ -1,0 +1,111 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Portability\Formatters;
+
+use RuntimeException;
+use ZipArchive;
+
+class CsvFormatter
+{
+    /**
+     * Format data as CSV (zipped with multiple files).
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function format( array $data ): string
+    {
+        $tempDir = sys_get_temp_dir() . '/export_' . uniqid();
+        mkdir( $tempDir, 0755, true );
+
+        $zipPath = $tempDir . '.zip';
+
+        $zip    = new ZipArchive;
+        $result = $zip->open( $zipPath, ZipArchive::CREATE );
+        if ( true !== $result ) {
+            throw new RuntimeException( "Failed to create ZIP archive: error code {$result}" );
+        }
+
+        // Add export info as JSON
+        if ( isset( $data['export_info'] ) ) {
+            $zip->addFromString( 'export_info.json', json_encode( $data['export_info'], JSON_PRETTY_PRINT ) );
+        }
+
+        // Add each data category as separate CSV
+        if ( isset( $data['data'] ) ) {
+            foreach ( $data['data'] as $name => $categoryData ) {
+                if ( isset( $categoryData['records'] ) && is_array( $categoryData['records'] ) ) {
+                    $csv = $this->arrayToCsv( $categoryData['records'] );
+                    $zip->addFromString( $name . '.csv', $csv );
+
+                    // Also add schema
+                    if ( isset( $categoryData['schema'] ) ) {
+                        $zip->addFromString( $name . '_schema.json', json_encode( $categoryData['schema'], JSON_PRETTY_PRINT ) );
+                    }
+                }
+            }
+        }
+
+        $zip->close();
+
+        $content = file_get_contents( $zipPath );
+        if ( false === $content ) {
+            @unlink( $zipPath );
+            @rmdir( $tempDir );
+            throw new RuntimeException( 'Failed to read ZIP archive content' );
+        }
+
+        // Cleanup
+        unlink( $zipPath );
+        rmdir( $tempDir );
+
+        return $content;
+    }
+
+    /**
+     * Get MIME type.
+     */
+    public function getMimeType(): string
+    {
+        return 'application/zip';
+    }
+
+    /**
+     * Convert array to CSV string.
+     *
+     * @param  array<int, array<string, mixed>>  $data
+     */
+    protected function arrayToCsv( array $data ): string
+    {
+        if ( empty( $data ) ) {
+            return '';
+        }
+
+        $output = fopen( 'php://temp', 'r+' );
+
+        // Get headers from first row
+        $first   = reset( $data );
+        $headers = is_array( $first ) ? array_keys( $first ) : [];
+
+        if ( ! empty( $headers ) ) {
+            fputcsv( $output, $headers );
+        }
+
+        foreach ( $data as $row ) {
+            if ( is_array( $row ) ) {
+                // Flatten nested arrays
+                $flatRow = array_map( function ( $value ) {
+                    return is_array( $value ) ? json_encode( $value ) : $value;
+                }, $row );
+                fputcsv( $output, $flatRow );
+            }
+        }
+
+        rewind( $output );
+        $csv = stream_get_contents( $output );
+        fclose( $output );
+
+        return $csv;
+    }
+}

--- a/src/Compliance/Portability/Formatters/JsonFormatter.php
+++ b/src/Compliance/Portability/Formatters/JsonFormatter.php
@@ -1,0 +1,46 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Portability\Formatters;
+use JsonException;
+use RuntimeException;
+
+class JsonFormatter
+{
+    /**
+     * Format data as JSON.
+     *
+     * @param  array<string, mixed>  $data
+     *
+     * @throws JsonException When JSON encoding fails
+     */
+    public function format( array $data ): string
+    {
+        return json_encode( $data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR );
+    }
+
+    /**
+     * Parse JSON content.
+     *
+     * @return array<string, mixed>
+     */
+    public function parse( string $content ): array
+    {
+        $result = json_decode( $content, true, 512, JSON_THROW_ON_ERROR );
+        
+        if ( !is_array( $result ) ) {
+            throw new RuntimeException( 'JSON content did not decode to an array' );
+        }
+        
+        return $result;
+    }
+
+    /**
+     * Get MIME type.
+     */
+    public function getMimeType(): string
+    {
+        return 'application/json';
+    }
+}

--- a/src/Compliance/Portability/Formatters/XmlFormatter.php
+++ b/src/Compliance/Portability/Formatters/XmlFormatter.php
@@ -1,0 +1,107 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Portability\Formatters;
+use DOMDocument;
+use InvalidArgumentException;
+use SimpleXMLElement;
+
+class XmlFormatter
+{
+    /**
+     * Format data as XML.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function format( array $data ): string
+    {
+        $xml = new SimpleXMLElement( '<?xml version="1.0" encoding="UTF-8"?><data_export></data_export>' );
+
+        $this->arrayToXml( $data, $xml );
+
+        $dom                     = new DOMDocument( '1.0', 'UTF-8' );
+        $dom->preserveWhiteSpace = false;
+        $dom->formatOutput       = true;
+        $dom->loadXML( $xml->asXML() );
+
+        return $dom->saveXML();
+    }
+
+    /**
+     * Parse XML content.
+     *
+     *
+     * @throws InvalidArgumentException When the XML content is malformed
+     *
+     * @return array<string, mixed>
+     */
+    public function parse( string $content ): array
+    {
+        // Enable internal error handling to capture libxml errors
+        $previousUseErrors = libxml_use_internal_errors( true );
+
+        // Disable entity loader for PHP < 8.0 to prevent XXE attacks
+        // In PHP 8.0+, external entity loading is disabled by default
+        if ( PHP_VERSION_ID < 80000 ) {
+            libxml_disable_entity_loader( true );
+        }
+
+        // Use LIBXML_NONET to block network fetches and prevent XXE
+        // Do NOT use LIBXML_NOENT as it enables entity substitution which is a security risk
+        $xml = simplexml_load_string( $content, SimpleXMLElement::class, LIBXML_NONET );
+
+        if ( false === $xml ) {
+            $errors = libxml_get_errors();
+            libxml_clear_errors();
+            libxml_use_internal_errors( $previousUseErrors );
+
+            $errorMessages = array_map(
+                fn ( $error ) => trim( $error->message ),
+                $errors,
+            );
+
+            throw new InvalidArgumentException(
+                'Failed to parse XML content: ' . implode( '; ', $errorMessages ),
+            );
+        }
+
+        libxml_clear_errors();
+        libxml_use_internal_errors( $previousUseErrors );
+
+        return json_decode( json_encode( $xml ), true );
+    }
+
+    /**
+     * Get MIME type.
+     */
+    public function getMimeType(): string
+    {
+        return 'application/xml';
+    }
+
+    /**
+     * Convert array to XML.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    protected function arrayToXml( array $data, SimpleXMLElement &$xml ): void
+    {
+        foreach ( $data as $key => $value ) {
+            // Handle numeric keys
+            if ( is_numeric( $key ) ) {
+                $key = 'item';
+            }
+
+            // Sanitize key name for XML
+            $key = preg_replace( '/[^a-zA-Z0-9_-]/', '_', $key );
+
+            if ( is_array( $value ) ) {
+                $subnode = $xml->addChild( $key );
+                $this->arrayToXml( $value, $subnode );
+            } else {
+                $xml->addChild( $key, htmlspecialchars( (string) $value ) );
+            }
+        }
+    }
+}

--- a/src/Compliance/Portability/PortabilityService.php
+++ b/src/Compliance/Portability/PortabilityService.php
@@ -1,0 +1,320 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Portability;
+
+use ArtisanPackUI\Compliance\Compliance\Contracts\DataExporterInterface;
+use ArtisanPackUI\Compliance\Events\DataExportCompleted;
+use ArtisanPackUI\Compliance\Events\DataExportRequested;
+use ArtisanPackUI\Compliance\Models\PortabilityRequest;
+use Carbon\Carbon;
+use Exception;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+
+class PortabilityService
+{
+    /**
+     * @var array<string, DataExporterInterface>
+     */
+    protected array $exporters = [];
+
+    protected DataPackager $packager;
+
+    public function __construct( ?DataPackager $packager = null )
+    {
+        $this->packager = $packager ?? app()->make( DataPackager::class );
+    }
+
+    /**
+     * Register a data exporter.
+     */
+    public function registerExporter( DataExporterInterface $exporter ): void
+    {
+        $this->exporters[ $exporter->getName() ] = $exporter;
+    }
+
+    /**
+     * Get all registered exporters.
+     *
+     * @return array<string, DataExporterInterface>
+     */
+    public function getExporters(): array
+    {
+        return $this->exporters;
+    }
+
+    /**
+     * Create a portability request.
+     *
+     * @param  array<string, mixed>  $options
+     */
+    public function createRequest( int $userId, array $options = [] ): PortabilityRequest
+    {
+        $defaultDeadlineDays = config( 'artisanpack.compliance.compliance.portability.default_deadline_days', 30 );
+        $deadlineAt          = $options['deadline_at'] ?? Carbon::now()->addDays( $defaultDeadlineDays );
+
+        $request = PortabilityRequest::create( [
+            'user_id'         => $userId,
+            'requester_type'  => $options['requester_type'] ?? 'self',
+            'status'          => 'pending',
+            'format'          => $options['format'] ?? config( 'artisanpack.compliance.compliance.portability.default_format', 'json' ),
+            'categories'      => $options['categories'] ?? null,
+            'transfer_type'   => $options['transfer_type'] ?? 'download',
+            'destination_url' => $options['destination_url'] ?? null,
+            'download_limit'  => config( 'artisanpack.compliance.compliance.portability.max_download_attempts', 5 ),
+            'deadline_at'     => $deadlineAt,
+            'created_by'      => auth()->id(),
+        ] );
+
+        event( new DataExportRequested( $request ) );
+
+        return $request;
+    }
+
+    /**
+     * Process a portability request.
+     */
+    public function processRequest( PortabilityRequest $request ): PortabilityRequest
+    {
+        $request->update( ['status' => 'processing'] );
+
+        try {
+            // Collect data from all exporters
+            $data = $this->collectUserData( $request->user_id, $request->categories );
+
+            // Package the data
+            $package = $this->packager->package(
+                $data,
+                $request->format,
+                $request->user_id,
+            );
+
+            // Store the package
+            $path = $this->storeExport( $package, $request );
+
+            // Calculate expiry
+            $expiryHours = config( 'artisanpack.compliance.compliance.portability.download_expiry_hours', 72 );
+
+            $request->update( [
+                'status'       => 'completed',
+                'file_path'    => $path,
+                'file_size'    => $package->getSize(),
+                'file_hash'    => $package->getHash(),
+                'completed_at' => now(),
+                'expires_at'   => now()->addHours( $expiryHours ),
+            ] );
+
+            event( new DataExportCompleted( $request ) );
+
+            // Handle direct transfer if requested
+            if ( 'direct_transfer' === $request->transfer_type && $request->destination_url ) {
+                $this->transferToDestination( $request );
+            }
+
+            return $request->fresh();
+        } catch ( Exception $e ) {
+            // Log the exception with context before re-throwing
+            Log::error( 'Portability request processing failed', [
+                'request_id'     => $request->id,
+                'request_number' => $request->request_number,
+                'user_id'        => $request->user_id,
+                'transfer_type'  => $request->transfer_type,
+                'format'         => $request->format,
+                'error'          => $e->getMessage(),
+                'trace'          => $e->getTraceAsString(),
+            ] );
+
+            $request->update( [
+                'status' => 'failed',
+            ] );
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Collect user data from all exporters.
+     *
+     * @param  array<string>|null  $categories
+     *
+     * @return array<string, mixed>
+     */
+    public function collectUserData( int $userId, ?array $categories = null ): array
+    {
+        $data = [
+            'export_info' => [
+                'generated_at'   => now()->toIso8601String(),
+                'format_version' => '1.0',
+                'organization'   => config( 'app.name' ),
+            ],
+            'data' => [],
+        ];
+
+        foreach ( $this->exporters as $name => $exporter ) {
+            // Skip if categories specified and exporter not in list
+            if ( null !== $categories && ! in_array( $exporter->getCategory(), $categories ) ) {
+                continue;
+            }
+
+            $exporterData = $exporter->getData( $userId );
+
+            if ( $exporterData->isNotEmpty() ) {
+                $data['data'][ $name ] = [
+                    'category' => $exporter->getCategory(),
+                    'schema'   => $exporter->getSchema(),
+                    'records'  => $exporter->transform( $exporterData ),
+                ];
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Preview what data will be exported.
+     */
+    public function previewExport( int $userId ): Collection
+    {
+        $preview = collect();
+
+        foreach ( $this->exporters as $name => $exporter ) {
+            $count = $exporter->getRecordCount( $userId );
+
+            $preview->put( $name, [
+                'name'         => $exporter->getName(),
+                'category'     => $exporter->getCategory(),
+                'record_count' => $count,
+                'formats'      => $exporter->getSupportedFormats(),
+            ] );
+        }
+
+        return $preview;
+    }
+
+    /**
+     * Download an export.
+     *
+     * @return array{path: string, name: string}|null
+     */
+    public function download( PortabilityRequest $request ): ?array
+    {
+        if ( ! $request->canDownload() ) {
+            return null;
+        }
+
+        $request->incrementDownloadCount();
+
+        return [
+            'path' => $request->file_path,
+            'name' => $this->getDownloadFilename( $request ),
+        ];
+    }
+
+    /**
+     * Get available export categories.
+     *
+     * @return array<string>
+     */
+    public function getCategories(): array
+    {
+        $categories = [];
+
+        foreach ( $this->exporters as $exporter ) {
+            $category = $exporter->getCategory();
+            if ( ! in_array( $category, $categories ) ) {
+                $categories[] = $category;
+            }
+        }
+
+        return $categories;
+    }
+
+    /**
+     * Get supported formats.
+     *
+     * @return array<string>
+     */
+    public function getSupportedFormats(): array
+    {
+        return config( 'artisanpack.compliance.compliance.portability.supported_formats', ['json', 'xml', 'csv'] );
+    }
+
+    /**
+     * Cleanup expired exports.
+     */
+    public function cleanupExpired(): int
+    {
+        $disk  = config( 'artisanpack.compliance.compliance.portability.storage_disk', 'local' );
+        $count = 0;
+
+        $expired = PortabilityRequest::expired()->get();
+
+        foreach ( $expired as $request ) {
+            if ( $request->file_path && Storage::disk( $disk )->exists( $request->file_path ) ) {
+                Storage::disk( $disk )->delete( $request->file_path );
+                $count++;
+            }
+
+            $request->update( [
+                'status'    => 'expired',
+                'file_path' => null,
+            ] );
+        }
+
+        return $count;
+    }
+
+    /**
+     * Store the export package.
+     */
+    protected function storeExport( ExportPackage $package, PortabilityRequest $request ): string
+    {
+        $disk     = config( 'artisanpack.compliance.compliance.portability.storage_disk', 'local' );
+        $basePath = 'data-exports';
+
+        $filename = sprintf(
+            '%s-%s.%s',
+            $request->request_number,
+            now()->format( 'Y-m-d-His' ),
+            $package->getExtension(),
+        );
+
+        $path = $basePath . '/' . $filename;
+
+        Storage::disk( $disk )->put( $path, $package->getContent() );
+
+        return $path;
+    }
+
+    /**
+     * Transfer export to external destination.
+     */
+    protected function transferToDestination( PortabilityRequest $request ): void
+    {
+        // TODO: Implement direct transfer logic
+        // This would typically use an HTTP client to POST the data
+        // to the destination URL after verification
+    }
+
+    /**
+     * Get download filename.
+     */
+    protected function getDownloadFilename( PortabilityRequest $request ): string
+    {
+        $extension = match ( $request->format ) {
+            'json'  => 'json',
+            'xml'   => 'xml',
+            'csv'   => 'zip',
+            default => 'json',
+        };
+
+        return sprintf(
+            'data-export-%s.%s',
+            $request->request_number,
+            $extension,
+        );
+    }
+}

--- a/src/Compliance/Portability/PortabilityService.php
+++ b/src/Compliance/Portability/PortabilityService.php
@@ -53,18 +53,18 @@ class PortabilityService
      */
     public function createRequest( int $userId, array $options = [] ): PortabilityRequest
     {
-        $defaultDeadlineDays = config( 'artisanpack.compliance.compliance.portability.default_deadline_days', 30 );
+        $defaultDeadlineDays = config( 'artisanpack.compliance.portability.default_deadline_days', 30 );
         $deadlineAt          = $options['deadline_at'] ?? Carbon::now()->addDays( $defaultDeadlineDays );
 
         $request = PortabilityRequest::create( [
             'user_id'         => $userId,
             'requester_type'  => $options['requester_type'] ?? 'self',
             'status'          => 'pending',
-            'format'          => $options['format'] ?? config( 'artisanpack.compliance.compliance.portability.default_format', 'json' ),
+            'format'          => $options['format'] ?? config( 'artisanpack.compliance.portability.default_format', 'json' ),
             'categories'      => $options['categories'] ?? null,
             'transfer_type'   => $options['transfer_type'] ?? 'download',
             'destination_url' => $options['destination_url'] ?? null,
-            'download_limit'  => config( 'artisanpack.compliance.compliance.portability.max_download_attempts', 5 ),
+            'download_limit'  => config( 'artisanpack.compliance.portability.max_download_attempts', 5 ),
             'deadline_at'     => $deadlineAt,
             'created_by'      => auth()->id(),
         ] );
@@ -96,7 +96,7 @@ class PortabilityService
             $path = $this->storeExport( $package, $request );
 
             // Calculate expiry
-            $expiryHours = config( 'artisanpack.compliance.compliance.portability.download_expiry_hours', 72 );
+            $expiryHours = config( 'artisanpack.compliance.portability.download_expiry_hours', 72 );
 
             $request->update( [
                 'status'       => 'completed',
@@ -239,7 +239,7 @@ class PortabilityService
      */
     public function getSupportedFormats(): array
     {
-        return config( 'artisanpack.compliance.compliance.portability.supported_formats', ['json', 'xml', 'csv'] );
+        return config( 'artisanpack.compliance.portability.supported_formats', ['json', 'xml', 'csv'] );
     }
 
     /**
@@ -247,7 +247,7 @@ class PortabilityService
      */
     public function cleanupExpired(): int
     {
-        $disk  = config( 'artisanpack.compliance.compliance.portability.storage_disk', 'local' );
+        $disk  = config( 'artisanpack.compliance.portability.storage_disk', 'local' );
         $count = 0;
 
         $expired = PortabilityRequest::expired()->get();
@@ -272,7 +272,7 @@ class PortabilityService
      */
     protected function storeExport( ExportPackage $package, PortabilityRequest $request ): string
     {
-        $disk     = config( 'artisanpack.compliance.compliance.portability.storage_disk', 'local' );
+        $disk     = config( 'artisanpack.compliance.portability.storage_disk', 'local' );
         $basePath = 'data-exports';
 
         $filename = sprintf(

--- a/src/Compliance/Portability/PortabilityService.php
+++ b/src/Compliance/Portability/PortabilityService.php
@@ -11,6 +11,7 @@ use ArtisanPackUI\Compliance\Models\PortabilityRequest;
 use Carbon\Carbon;
 use Exception;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 
@@ -66,10 +67,14 @@ class PortabilityService
             'destination_url' => $options['destination_url'] ?? null,
             'download_limit'  => config( 'artisanpack.compliance.portability.max_download_attempts', 5 ),
             'deadline_at'     => $deadlineAt,
-            'created_by'      => auth()->id(),
+            // Allow callers (jobs, console commands) to pass their own
+            // actor — auth()->id() is null in unauthenticated contexts.
+            'created_by'      => $options['created_by'] ?? auth()->id(),
         ] );
 
-        event( new DataExportRequested( $request ) );
+        // Defer dispatch until commit so listeners don't run for a record
+        // that gets rolled back. Matches ConsentManager's pattern.
+        DB::afterCommit( fn () => event( new DataExportRequested( $request ) ) );
 
         return $request;
     }
@@ -107,7 +112,7 @@ class PortabilityService
                 'expires_at'   => now()->addHours( $expiryHours ),
             ] );
 
-            event( new DataExportCompleted( $request ) );
+            DB::afterCommit( fn () => event( new DataExportCompleted( $request ) ) );
 
             // Handle direct transfer if requested
             if ( 'direct_transfer' === $request->transfer_type && $request->destination_url ) {

--- a/src/Compliance/Reporting/ComplianceReport.php
+++ b/src/Compliance/Reporting/ComplianceReport.php
@@ -1,0 +1,59 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Reporting;
+use DateTimeInterface;
+
+class ComplianceReport
+{
+    public readonly DateTimeInterface $generatedAt;
+
+    /**
+     * @param  array<string, mixed>  $sections
+     * @param  array<string, mixed>  $metadata
+     */
+    public function __construct(
+        public readonly string $type,
+        public readonly string $title,
+        public readonly array $sections,
+        public readonly array $metadata = [],
+        ?DateTimeInterface $generatedAt = null,
+    ) {
+        $this->generatedAt = $generatedAt ?? now();
+    }
+
+    /**
+     * Get section by name.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function getSection( string $name ): ?array
+    {
+        return $this->sections[ $name ] ?? null;
+    }
+
+    /**
+     * Convert to array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'type'         => $this->type,
+            'title'        => $this->title,
+            'generated_at' => $this->generatedAt->format( 'c' ),
+            'metadata'     => $this->metadata,
+            'sections'     => $this->sections,
+        ];
+    }
+
+    /**
+     * Convert to JSON.
+     */
+    public function toJson(): string
+    {
+        return json_encode( $this->toArray(), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE );
+    }
+}

--- a/src/Compliance/Reporting/ReportGenerator.php
+++ b/src/Compliance/Reporting/ReportGenerator.php
@@ -1,0 +1,230 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Reporting;
+
+use ArtisanPackUI\Compliance\Compliance\Contracts\ReportTypeInterface;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Storage;
+use InvalidArgumentException;
+
+class ReportGenerator
+{
+    /**
+     * @var array<string, ReportTypeInterface>
+     */
+    protected array $reportTypes = [];
+
+    /**
+     * Register a report type.
+     */
+    public function registerReportType( ReportTypeInterface $reportType ): void
+    {
+        $this->reportTypes[ $reportType->getName() ] = $reportType;
+    }
+
+    /**
+     * Get all available report types.
+     *
+     * @return array<string, ReportTypeInterface>
+     */
+    public function getReportTypes(): array
+    {
+        return $this->reportTypes;
+    }
+
+    /**
+     * Generate a report.
+     *
+     * @param  array<string, mixed>  $options
+     */
+    public function generate( string $type, array $options = [] ): ComplianceReport
+    {
+        if ( ! isset( $this->reportTypes[ $type ] ) ) {
+            throw new InvalidArgumentException( "Unknown report type: {$type}" );
+        }
+
+        return $this->reportTypes[ $type ]->generate( $options );
+    }
+
+    /**
+     * Export report to file.
+     */
+    public function export( ComplianceReport $report, string $format = 'json' ): string
+    {
+        $content = match ( $format ) {
+            'json'  => $report->toJson(),
+            'html'  => $this->renderHtml( $report ),
+            'csv'   => $this->renderCsv( $report ),
+            default => throw new InvalidArgumentException( "Unsupported format: {$format}" ),
+        };
+
+        $filename = sprintf(
+            '%s-%s.%s',
+            $report->type,
+            now()->format( 'Y-m-d-His' ),
+            $format,
+        );
+
+        $path = config( 'artisanpack.compliance.compliance.reporting.storage_path', 'compliance-reports' ) . '/' . $filename;
+        $disk = config( 'artisanpack.compliance.compliance.reporting.storage_disk', 'local' );
+
+        Storage::disk( $disk )->put( $path, $content );
+
+        return $path;
+    }
+
+    /**
+     * Get report history.
+     */
+    public function getHistory( ?string $type = null, int $limit = 20 ): Collection
+    {
+        $disk = config( 'artisanpack.compliance.compliance.reporting.storage_disk', 'local' );
+        $path = config( 'artisanpack.compliance.compliance.reporting.storage_path', 'compliance-reports' );
+
+        $files = Storage::disk( $disk )->files( $path );
+
+        $reports = collect( $files )->map( function ( $file ) use ( $disk ) {
+            $parts = pathinfo( $file );
+
+            return [
+                'path'       => $file,
+                'filename'   => $parts['basename'],
+                'type'       => explode( '-', $parts['filename'] )[0] ?? 'unknown',
+                'format'     => $parts['extension'] ?? 'json',
+                'size'       => Storage::disk( $disk )->size( $file ),
+                'created_at' => Storage::disk( $disk )->lastModified( $file ),
+            ];
+        } )->sortByDesc( 'created_at' );
+
+        if ( $type ) {
+            $reports = $reports->filter( fn ( $r ) => $r['type'] === $type );
+        }
+
+        return $reports->take( $limit )->values();
+    }
+
+    /**
+     * Render report as HTML.
+     */
+    protected function renderHtml( ComplianceReport $report ): string
+    {
+        $html = '<!DOCTYPE html><html><head><meta charset="UTF-8">';
+        $html .= '<title>' . htmlspecialchars( $report->title ) . '</title>';
+        $html .= '<style>body{font-family:sans-serif;margin:40px}h1{color:#333}table{border-collapse:collapse;width:100%}th,td{border:1px solid #ddd;padding:8px;text-align:left}th{background:#f4f4f4}</style>';
+        $html .= '</head><body>';
+        $html .= '<h1>' . htmlspecialchars( $report->title ) . '</h1>';
+        $html .= '<p>Generated: ' . htmlspecialchars( $report->generatedAt->format( 'Y-m-d H:i:s' ) ) . '</p>';
+
+        foreach ( $report->sections as $name => $section ) {
+            $html .= '<h2>' . htmlspecialchars( ucfirst( str_replace( '_', ' ', $name ) ) ) . '</h2>';
+            $html .= $this->renderSectionHtml( $section );
+        }
+
+        $html .= '</body></html>';
+
+        return $html;
+    }
+
+    /**
+     * Render a section as HTML.
+     *
+     * @param  array<string, mixed>|mixed  $section
+     */
+    protected function renderSectionHtml( mixed $section ): string
+    {
+        if ( is_array( $section ) ) {
+            if ( $this->isAssociativeArray( $section ) ) {
+                $html = '<table>';
+                foreach ( $section as $key => $value ) {
+                    $html .= '<tr><th>' . htmlspecialchars( ucfirst( str_replace( '_', ' ', $key ) ) ) . '</th>';
+                    $html .= '<td>' . $this->renderValue( $value ) . '</td></tr>';
+                }
+                $html .= '</table>';
+
+                return $html;
+            }
+
+            $html = '<ul>';
+            foreach ( $section as $item ) {
+                $html .= '<li>' . $this->renderValue( $item ) . '</li>';
+            }
+            $html .= '</ul>';
+
+            return $html;
+        }
+
+        return htmlspecialchars( (string) $section );
+    }
+
+    /**
+     * Render value as HTML.
+     */
+    protected function renderValue( mixed $value ): string
+    {
+        if ( is_array( $value ) ) {
+            return $this->renderSectionHtml( $value );
+        }
+
+        if ( is_bool( $value ) ) {
+            return $value ? 'Yes' : 'No';
+        }
+
+        return htmlspecialchars( (string) $value );
+    }
+
+    /**
+     * Render report as CSV.
+     */
+    protected function renderCsv( ComplianceReport $report ): string
+    {
+        $output = fopen( 'php://temp', 'r+' );
+
+        fputcsv( $output, ['Report Type', $report->type] );
+        fputcsv( $output, ['Title', $report->title] );
+        fputcsv( $output, ['Generated At', $report->generatedAt->format( 'Y-m-d H:i:s' )] );
+        fputcsv( $output, [] );
+
+        foreach ( $report->sections as $name => $section ) {
+            fputcsv( $output, ['--- ' . strtoupper( $name ) . ' ---'] );
+            $this->renderSectionCsv( $output, $section );
+            fputcsv( $output, [] );
+        }
+
+        rewind( $output );
+        $csv = stream_get_contents( $output );
+        fclose( $output );
+
+        return $csv;
+    }
+
+    /**
+     * Render section as CSV.
+     *
+     * @param  resource  $output
+     * @param  array<string, mixed>|mixed  $section
+     */
+    protected function renderSectionCsv( $output, mixed $section, string $prefix = '' ): void
+    {
+        if ( is_array( $section ) ) {
+            foreach ( $section as $key => $value ) {
+                if ( is_array( $value ) ) {
+                    fputcsv( $output, [$prefix . $key, json_encode( $value )] );
+                } else {
+                    fputcsv( $output, [$prefix . $key, $value] );
+                }
+            }
+        }
+    }
+
+    /**
+     * Check if array is associative.
+     *
+     * @param  array<mixed>  $array
+     */
+    protected function isAssociativeArray( array $array ): bool
+    {
+        return array_keys( $array ) !== range( 0, count( $array) - 1);
+    }
+}

--- a/src/Compliance/Reporting/ReportGenerator.php
+++ b/src/Compliance/Reporting/ReportGenerator.php
@@ -67,8 +67,8 @@ class ReportGenerator
             $format,
         );
 
-        $path = config( 'artisanpack.compliance.compliance.reporting.storage_path', 'compliance-reports' ) . '/' . $filename;
-        $disk = config( 'artisanpack.compliance.compliance.reporting.storage_disk', 'local' );
+        $path = config( 'artisanpack.compliance.reporting.storage_path', 'compliance-reports' ) . '/' . $filename;
+        $disk = config( 'artisanpack.compliance.reporting.storage_disk', 'local' );
 
         Storage::disk( $disk )->put( $path, $content );
 
@@ -80,8 +80,8 @@ class ReportGenerator
      */
     public function getHistory( ?string $type = null, int $limit = 20 ): Collection
     {
-        $disk = config( 'artisanpack.compliance.compliance.reporting.storage_disk', 'local' );
-        $path = config( 'artisanpack.compliance.compliance.reporting.storage_path', 'compliance-reports' );
+        $disk = config( 'artisanpack.compliance.reporting.storage_disk', 'local' );
+        $path = config( 'artisanpack.compliance.reporting.storage_path', 'compliance-reports' );
 
         $files = Storage::disk( $disk )->files( $path );
 

--- a/src/Compliance/Reporting/Reports/ComplianceStatusReport.php
+++ b/src/Compliance/Reporting/Reports/ComplianceStatusReport.php
@@ -1,0 +1,217 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Reporting\Reports;
+
+use ArtisanPackUI\Compliance\Compliance\Contracts\ReportTypeInterface;
+use ArtisanPackUI\Compliance\Compliance\Monitoring\ComplianceMonitor;
+use ArtisanPackUI\Compliance\Compliance\Reporting\ComplianceReport;
+use ArtisanPackUI\Compliance\Models\ComplianceScore;
+use ArtisanPackUI\Compliance\Models\ComplianceViolation;
+use ArtisanPackUI\Compliance\Models\ErasureRequest;
+use ArtisanPackUI\Compliance\Models\PortabilityRequest;
+
+class ComplianceStatusReport implements ReportTypeInterface
+{
+    public function __construct( protected ComplianceMonitor $monitor )
+    {
+    }
+
+    /**
+     * Get report type name.
+     */
+    public function getName(): string
+    {
+        return 'compliance_status';
+    }
+
+    /**
+     * Get report type description.
+     */
+    public function getDescription(): string
+    {
+        return 'Overall compliance status report including scores, violations, and DSR metrics';
+    }
+
+    /**
+     * Get report category.
+     */
+    public function getCategory(): string
+    {
+        return 'compliance';
+    }
+
+    /**
+     * Generate the report.
+     *
+     * @param  array<string, mixed>  $options
+     */
+    public function generate( array $options = [] ): ComplianceReport
+    {
+        $score      = ComplianceScore::getLatest();
+        $violations = ComplianceViolation::open()->get();
+
+        $sections = [
+            'summary'               => $this->generateSummary( $score ),
+            'compliance_score'      => $this->generateScoreSection( $score ),
+            'violations'            => $this->generateViolationsSection( $violations ),
+            'data_subject_requests' => $this->generateDsrSection(),
+            'check_results'         => $this->generateCheckResultsSection(),
+        ];
+
+        return new ComplianceReport(
+            type: $this->getName(),
+            title: 'Compliance Status Report',
+            sections: $sections,
+            metadata: [
+                'regulation'   => $options['regulation'] ?? 'all',
+                'generated_by' => auth()->user()?->name ?? 'system',
+            ],
+        );
+    }
+
+    /**
+     * Get available options.
+     *
+     * @return array<string, mixed>
+     */
+    public function getAvailableOptions(): array
+    {
+        return [
+            'regulation' => [
+                'type'    => 'select',
+                'options' => ['all', 'gdpr', 'ccpa', 'lgpd'],
+                'default' => 'all',
+            ],
+        ];
+    }
+
+    /**
+     * Get supported formats.
+     *
+     * @return array<string>
+     */
+    public function getSupportedFormats(): array
+    {
+        return ['json', 'html', 'csv', 'pdf'];
+    }
+
+    /**
+     * Get default schedule.
+     */
+    public function getDefaultSchedule(): ?string
+    {
+        return '0 8 * * 1'; // Weekly on Monday at 8am
+    }
+
+    /**
+     * Generate summary section.
+     *
+     * @return array<string, mixed>
+     */
+    protected function generateSummary( ?ComplianceScore $score ): array
+    {
+        $violations = ComplianceViolation::open();
+
+        return [
+            'overall_score'       => $score?->overall_score ?? 'N/A',
+            'grade'               => $score?->getGrade() ?? 'N/A',
+            'status'              => $score && $score->isPassing() ? 'Compliant' : 'Non-Compliant',
+            'open_violations'     => $violations->count(),
+            'critical_violations' => $violations->where( 'severity', 'critical' )->count(),
+            'report_period'       => now()->format( 'F Y' ),
+        ];
+    }
+
+    /**
+     * Generate score section.
+     *
+     * @return array<string, mixed>
+     */
+    protected function generateScoreSection( ?ComplianceScore $score ): array
+    {
+        return [
+            'overall'         => $score?->overall_score ?? 0,
+            'category_scores' => $score?->category_scores ?? [],
+            'findings'        => $score?->findings ?? [],
+            'recommendations' => $score?->recommendations ?? [],
+            'calculated_at'   => $score?->calculated_at?->toIso8601String(),
+        ];
+    }
+
+    /**
+     * Generate violations section.
+     *
+     * @param  \Illuminate\Support\Collection<int, ComplianceViolation>  $violations
+     *
+     * @return array<string, mixed>
+     */
+    protected function generateViolationsSection( $violations ): array
+    {
+        return [
+            'total_open'  => $violations->count(),
+            'by_severity' => [
+                'critical' => $violations->where( 'severity', 'critical' )->count(),
+                'high'     => $violations->where( 'severity', 'high' )->count(),
+                'medium'   => $violations->where( 'severity', 'medium' )->count(),
+                'low'      => $violations->where( 'severity', 'low' )->count(),
+            ],
+            'by_category' => $violations->groupBy( 'category' )->map->count()->toArray(),
+            'overdue'     => $violations->filter->isOverdue()->count(),
+            'details'     => $violations->take( 10 )->map( fn ( $v ) => [
+                'number'     => $v->violation_number,
+                'title'      => $v->title,
+                'severity'   => $v->severity,
+                'status'     => $v->status,
+                'created_at' => $v->created_at->toIso8601String(),
+            ] )->toArray(),
+        ];
+    }
+
+    /**
+     * Generate DSR section.
+     *
+     * @return array<string, mixed>
+     */
+    protected function generateDsrSection(): array
+    {
+        return [
+            'erasure_requests' => [
+                'pending'              => ErasureRequest::pending()->count(),
+                'completed_this_month' => ErasureRequest::where( 'status', 'completed' )
+                    ->whereMonth( 'completed_at', now()->month )
+                    ->count(),
+                'overdue' => ErasureRequest::overdue()->count(),
+            ],
+            'portability_requests' => [
+                'pending'              => PortabilityRequest::pending()->count(),
+                'completed_this_month' => PortabilityRequest::where( 'status', 'completed' )
+                    ->whereMonth( 'completed_at', now()->month )
+                    ->count(),
+            ],
+        ];
+    }
+
+    /**
+     * Generate check results section.
+     *
+     * @return array<string, mixed>
+     */
+    protected function generateCheckResultsSection(): array
+    {
+        $results = $this->monitor->getLatestResults();
+
+        return [
+            'total_checks' => $results->count(),
+            'passed'       => $results->filter( fn ( $r ) => $r?->isPassed() )->count(),
+            'failed'       => $results->filter( fn ( $r ) => $r?->isFailed() )->count(),
+            'checks'       => $results->map( fn ( $r ) => $r ? [
+                'name'     => $r->check_name,
+                'status'   => $r->status,
+                'score'    => $r->score,
+                'last_run' => $r->created_at->toIso8601String(),
+            ] : null )->filter()->values()->toArray(),
+        ];
+    }
+}

--- a/src/Compliance/Traits/Auditable.php
+++ b/src/Compliance/Traits/Auditable.php
@@ -6,17 +6,22 @@ namespace ArtisanPackUI\Compliance\Compliance\Traits;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
 trait Auditable
 {
     /**
      * Get the audit trail for this record.
+     *
+     * The trait's default audit storage is the configured Laravel log
+     * channel (see {@see logAuditEvent}); apps that need a queryable
+     * audit trail should override this method *and* {@see storeAuditRecord}
+     * together to read from / write to their own audit-record table.
+     * Returns an empty collection by default.
      */
     public function getAuditTrail(): Collection
     {
-        // This would typically query an audit log table
-        // Returning empty collection as a placeholder
         return collect();
     }
 
@@ -63,7 +68,20 @@ trait Auditable
      */
     protected function getAuditExcludedAttributes(): array
     {
-        return $this->auditExcluded ?? ['password', 'remember_token'];
+        $excluded = $this->auditExcluded ?? ['password', 'remember_token'];
+
+        // When the model also uses PrivacyByDesign, fold its
+        // personal/sensitive attribute lists in automatically so PII
+        // can't leak into the audit channel by default.
+        if ( method_exists( $this, 'getPersonalDataAttributes' ) ) {
+            $excluded = array_merge( $excluded, $this->getPersonalDataAttributes() );
+        }
+
+        if ( method_exists( $this, 'getSensitiveDataAttributes' ) ) {
+            $excluded = array_merge( $excluded, $this->getSensitiveDataAttributes() );
+        }
+
+        return array_values( array_unique( $excluded ) );
     }
 
     /**
@@ -99,12 +117,20 @@ trait Auditable
             $data['original'] = array_intersect_key( $original, $changes );
         }
 
-        Log::channel( $this->getAuditLogChannel() )->info( "Model {$event}", $data );
+        // Defer the audit write until the surrounding DB transaction
+        // commits so a rolled-back save() doesn't leave a phantom audit
+        // entry claiming the change happened. DB::afterCommit runs
+        // immediately if there's no active transaction.
+        $channel  = $this->getAuditLogChannel();
+        $logTrail = (bool) config( 'artisanpack.compliance.privacy_by_design.audit_trail_enabled', true );
 
-        // Store in database if configured
-        if ( config( 'artisanpack.compliance.privacy_by_design.audit_trail_enabled', true ) ) {
-            $this->storeAuditRecord( $data );
-        }
+        DB::afterCommit( function () use ( $channel, $event, $data, $logTrail ): void {
+            Log::channel( $channel )->info( "Model {$event}", $data );
+
+            if ( $logTrail ) {
+                $this->storeAuditRecord( $data );
+            }
+        } );
     }
 
     /**

--- a/src/Compliance/Traits/Auditable.php
+++ b/src/Compliance/Traits/Auditable.php
@@ -1,0 +1,120 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Traits;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+
+trait Auditable
+{
+    /**
+     * Get the audit trail for this record.
+     */
+    public function getAuditTrail(): Collection
+    {
+        // This would typically query an audit log table
+        // Returning empty collection as a placeholder
+        return collect();
+    }
+
+    /**
+     * Log a custom audit event.
+     *
+     * @param  array<string, mixed>  $context
+     */
+    public function audit( string $action, array $context = [] ): void
+    {
+        $this->logAuditEvent( $action, $context );
+    }
+
+    /**
+     * Boot the Auditable trait.
+     */
+    protected static function bootAuditable(): void
+    {
+        static::created( function ( $model ): void {
+            $model->logAuditEvent( 'created' );
+        } );
+
+        static::updated( function ( $model ): void {
+            $model->logAuditEvent( 'updated', $model->getDirty(), $model->getOriginal() );
+        } );
+
+        static::deleted( function ( $model ): void {
+            $model->logAuditEvent( 'deleted' );
+        } );
+    }
+
+    /**
+     * Get the audit log channel.
+     */
+    protected function getAuditLogChannel(): string
+    {
+        return $this->auditLogChannel ?? 'audit';
+    }
+
+    /**
+     * Get attributes to exclude from audit logging.
+     *
+     * @return array<string>
+     */
+    protected function getAuditExcludedAttributes(): array
+    {
+        return $this->auditExcluded ?? ['password', 'remember_token'];
+    }
+
+    /**
+     * Log an audit event.
+     *
+     * @param  array<string, mixed>  $changes
+     * @param  array<string, mixed>  $original
+     */
+    protected function logAuditEvent( string $event, array $changes = [], array $original = [] ): void
+    {
+        $excluded = $this->getAuditExcludedAttributes();
+
+        // Filter out excluded attributes
+        $changes  = array_diff_key( $changes, array_flip( $excluded ) );
+        $original = array_diff_key( $original, array_flip( $excluded ) );
+
+        $data = [
+            'model'      => static::class,
+            'model_id'   => $this->getKey(),
+            'event'      => $event,
+            'user_id'    => Auth::id(),
+            'user_type'  => Auth::check() ? get_class( Auth::user() ) : null,
+            'ip_address' => request()?->ip(),
+            'user_agent' => request()?->userAgent(),
+            'timestamp'  => now()->toIso8601String(),
+        ];
+
+        if ( ! empty( $changes ) ) {
+            $data['changes'] = $changes;
+        }
+
+        if ( ! empty( $original ) && 'updated' === $event ) {
+            $data['original'] = array_intersect_key( $original, $changes );
+        }
+
+        Log::channel( $this->getAuditLogChannel() )->info( "Model {$event}", $data );
+
+        // Store in database if configured
+        if ( config( 'artisanpack.compliance.compliance.privacy_by_design.audit_trail_enabled', true ) ) {
+            $this->storeAuditRecord( $data );
+        }
+    }
+
+    /**
+     * Store audit record in database.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    protected function storeAuditRecord( array $data ): void
+    {
+        // This can be extended to store in a dedicated audit table
+        // For now, we rely on the log channel
+    }
+}

--- a/src/Compliance/Traits/Auditable.php
+++ b/src/Compliance/Traits/Auditable.php
@@ -102,7 +102,7 @@ trait Auditable
         Log::channel( $this->getAuditLogChannel() )->info( "Model {$event}", $data );
 
         // Store in database if configured
-        if ( config( 'artisanpack.compliance.compliance.privacy_by_design.audit_trail_enabled', true ) ) {
+        if ( config( 'artisanpack.compliance.privacy_by_design.audit_trail_enabled', true ) ) {
             $this->storeAuditRecord( $data );
         }
     }

--- a/src/Compliance/Traits/Auditable.php
+++ b/src/Compliance/Traits/Auditable.php
@@ -6,7 +6,6 @@ namespace ArtisanPackUI\Compliance\Compliance\Traits;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
 trait Auditable
@@ -119,12 +118,14 @@ trait Auditable
 
         // Defer the audit write until the surrounding DB transaction
         // commits so a rolled-back save() doesn't leave a phantom audit
-        // entry claiming the change happened. DB::afterCommit runs
-        // immediately if there's no active transaction.
+        // entry. Use the model's own connection (not the DB facade /
+        // default connection) so multi-database apps tie the callback
+        // to the right transaction. afterCommit runs immediately if
+        // there's no active transaction on that connection.
         $channel  = $this->getAuditLogChannel();
         $logTrail = (bool) config( 'artisanpack.compliance.privacy_by_design.audit_trail_enabled', true );
 
-        DB::afterCommit( function () use ( $channel, $event, $data, $logTrail ): void {
+        $this->getConnection()->afterCommit( function () use ( $channel, $event, $data, $logTrail ): void {
             Log::channel( $channel )->info( "Model {$event}", $data );
 
             if ( $logTrail ) {

--- a/src/Compliance/Traits/Auditable.php
+++ b/src/Compliance/Traits/Auditable.php
@@ -98,15 +98,21 @@ trait Auditable
         $original = array_diff_key( $original, array_flip( $excluded ) );
 
         $data = [
-            'model'      => static::class,
-            'model_id'   => $this->getKey(),
-            'event'      => $event,
-            'user_id'    => Auth::id(),
-            'user_type'  => Auth::check() ? get_class( Auth::user() ) : null,
-            'ip_address' => request()?->ip(),
-            'user_agent' => request()?->userAgent(),
-            'timestamp'  => now()->toIso8601String(),
+            'model'     => static::class,
+            'model_id'  => $this->getKey(),
+            'event'     => $event,
+            'user_id'   => Auth::id(),
+            'user_type' => Auth::check() ? get_class( Auth::user() ) : null,
+            'timestamp' => now()->toIso8601String(),
         ];
+
+        // IP / user-agent are personal data under most regimes — keep
+        // them off the audit payload by default and let apps opt in
+        // when their compliance posture allows it.
+        if ( (bool) config( 'artisanpack.compliance.privacy_by_design.audit_include_request_metadata', false ) ) {
+            $data['ip_address'] = request()?->ip();
+            $data['user_agent'] = request()?->userAgent();
+        }
 
         if ( ! empty( $changes ) ) {
             $data['changes'] = $changes;

--- a/src/Compliance/Traits/HasConsent.php
+++ b/src/Compliance/Traits/HasConsent.php
@@ -1,0 +1,136 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Traits;
+
+use ArtisanPackUI\Compliance\Models\ConsentRecord;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Collection;
+
+trait HasConsent
+{
+    /**
+     * Get all consent records for this user.
+     */
+    public function consentRecords(): HasMany
+    {
+        return $this->hasMany( ConsentRecord::class, 'user_id' );
+    }
+
+    /**
+     * Check if user has valid consent for a purpose.
+     */
+    public function hasConsentFor( string $purpose ): bool
+    {
+        return $this->consentRecords()
+            ->valid()
+            ->where( 'purpose', $purpose )
+            ->exists();
+    }
+
+    /**
+     * Get consent record for a specific purpose.
+     */
+    public function getConsentFor( string $purpose ): ?ConsentRecord
+    {
+        return $this->consentRecords()
+            ->where( 'purpose', $purpose )
+            ->latest()
+            ->first();
+    }
+
+    /**
+     * Get all valid consents.
+     */
+    public function getValidConsents(): Collection
+    {
+        return $this->consentRecords()
+            ->valid()
+            ->get();
+    }
+
+    /**
+     * Get consent status for multiple purposes.
+     *
+     * @param  array<string>  $purposes
+     *
+     * @return array<string, bool>
+     */
+    public function getConsentStatus( array $purposes ): array
+    {
+        $consents = $this->consentRecords()
+            ->valid()
+            ->whereIn( 'purpose', $purposes )
+            ->pluck( 'purpose' )
+            ->toArray();
+
+        $status = [];
+        foreach ( $purposes as $purpose ) {
+            $status[ $purpose ] = in_array( $purpose, $consents );
+        }
+
+        return $status;
+    }
+
+    /**
+     * Check if user needs to reconsent for any purposes.
+     *
+     * @return array<string>
+     */
+    public function getPurposesRequiringReconsent(): array
+    {
+        $purposes = [];
+
+        $consents = $this->consentRecords()
+            ->where( 'status', 'granted' )
+            ->with( 'policy' )
+            ->get();
+
+        foreach ( $consents as $consent ) {
+            if ( $consent->policy && ! $consent->policy->isEffective() ) {
+                $purposes[] = $consent->purpose;
+            }
+        }
+
+        return array_unique( $purposes );
+    }
+
+    /**
+     * Get consent history for user.
+     */
+    public function getConsentHistory( ?string $purpose = null ): Collection
+    {
+        $query = $this->consentRecords();
+
+        if ( $purpose ) {
+            $query->where( 'purpose', $purpose );
+        }
+
+        return $query->orderByDesc( 'created_at' )->get();
+    }
+
+    /**
+     * Check if user has any withdrawn consents.
+     */
+    public function hasWithdrawnConsents(): bool
+    {
+        return $this->consentRecords()
+            ->where( 'status', 'withdrawn' )
+            ->exists();
+    }
+
+    /**
+     * Get all purposes user has consented to (ever).
+     *
+     * @return array<string>
+     */
+    public function getAllConsentedPurposes(): array
+    {
+        return $this->consentRecords()
+            ->where( 'status', 'granted' )
+            ->distinct( 'purpose' )
+            ->pluck( 'purpose' )
+            ->toArray();
+    }
+}

--- a/src/Compliance/Traits/PrivacyByDesign.php
+++ b/src/Compliance/Traits/PrivacyByDesign.php
@@ -4,12 +4,13 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\Compliance\Compliance\Traits;
 
-use Exception;
+use ArtisanPackUI\Compliance\Compliance\Exceptions\DecryptionException;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use RuntimeException;
+use Throwable;
 
 trait PrivacyByDesign
 {
@@ -246,26 +247,21 @@ trait PrivacyByDesign
             // Otherwise → treat as plaintext and encrypt.
             $value = $this->attributes[ $attribute ];
 
-            // Crypt::encryptString and looksLikeEncryptedPayload both
-            // require a string (declare(strict_types=1) is on for this
-            // trait). Coerce scalars to string. Non-scalar values
-            // (arrays, objects, resources) fail CLOSED with an explicit
-            // exception — silently skipping them would leave the
-            // attribute persisted in plaintext, which is the opposite
-            // of what a privacy package should do. Apps storing
-            // structured sensitive data should JSON-encode (or
-            // otherwise serialize) before assigning to the attribute.
+            // Crypt::encryptString round-trips strings only. Rather than
+            // coerce non-string values (which silently loses type — int 0
+            // becomes "0", bool false becomes ""), reject anything that
+            // isn't already a string. Apps storing structured or typed
+            // sensitive data should serialize to a string (e.g. JSON-encode)
+            // before assigning to the attribute, so the round-trip semantics
+            // are explicit and reversible on the read side.
             if ( ! is_string( $value ) ) {
-                if ( ! is_scalar( $value ) ) {
-                    throw new InvalidArgumentException( sprintf(
-                        'PrivacyByDesign: sensitive attribute "%s" on %s holds a non-scalar value (%s); '
-                            . 'serialize it to a string before save (e.g. JSON-encode) so it can be encrypted.',
-                        $attribute,
-                        static::class,
-                        get_debug_type( $value ),
-                    ) );
-                }
-                $value = (string) $value;
+                throw new InvalidArgumentException( sprintf(
+                    'PrivacyByDesign: sensitive attribute "%s" on %s must be a string before encryption; got %s. '
+                        . 'Serialize structured / non-string scalar values explicitly (e.g. JSON-encode) before assignment.',
+                    $attribute,
+                    static::class,
+                    get_debug_type( $value ),
+                ) );
             }
 
             if ( $this->looksLikeEncryptedPayload( $value ) ) {
@@ -329,15 +325,22 @@ trait PrivacyByDesign
             return null;
         }
 
+        // The value passes looksLikeEncryptedPayload(), so a decrypt
+        // failure here means real broken ciphertext — rotated app
+        // key, tampered payload, or legacy encryption. Fail closed
+        // with a typed exception rather than returning null, which
+        // would conflate this with the absent / plaintext cases above
+        // and let callers (export, pseudonymize, etc.) ship opaque
+        // ciphertext as if it were a real value.
         try {
             return Crypt::decryptString( $value );
-        } catch ( Exception $e ) {
-            Log::warning( "Failed to decrypt attribute {$attribute}", [
-                'model' => static::class,
-                'id'    => $this->getKey(),
-            ] );
-
-            return null;
+        } catch ( Throwable $e ) {
+            throw new DecryptionException(
+                attribute: $attribute,
+                modelClass: static::class,
+                modelKey: $this->getKey(),
+                previous: $e,
+            );
         }
     }
 

--- a/src/Compliance/Traits/PrivacyByDesign.php
+++ b/src/Compliance/Traits/PrivacyByDesign.php
@@ -122,7 +122,7 @@ trait PrivacyByDesign
     public function hasPersonalData(): bool
     {
         foreach ( $this->getPersonalDataAttributes() as $attribute ) {
-            if ( ! empty( $this->attributes[ $attribute ] ) ) {
+            if ( $this->attributeIsPresent( $attribute ) ) {
                 return true;
             }
         }
@@ -136,7 +136,7 @@ trait PrivacyByDesign
     public function hasSensitiveData(): bool
     {
         foreach ( $this->getSensitiveDataAttributes() as $attribute ) {
-            if ( ! empty( $this->attributes[ $attribute ] ) ) {
+            if ( $this->attributeIsPresent( $attribute ) ) {
                 return true;
             }
         }
@@ -160,6 +160,25 @@ trait PrivacyByDesign
                 $this->attributes[ $attribute ] = '[REDACTED]';
             }
         }
+    }
+
+    /**
+     * Whether the given attribute holds an actual value.
+     *
+     * Plain `! empty(...)` treats `'0'`, `0`, and `false` as missing —
+     * which is wrong for personal/sensitive data where those are
+     * legitimate values (a "0" survey answer, a `false` consent flag,
+     * etc.). Use explicit null + empty-string checks instead.
+     */
+    protected function attributeIsPresent( string $attribute ): bool
+    {
+        if ( ! array_key_exists( $attribute, $this->attributes ) ) {
+            return false;
+        }
+
+        $value = $this->attributes[ $attribute ];
+
+        return null !== $value && '' !== $value;
     }
 
     /**
@@ -211,7 +230,7 @@ trait PrivacyByDesign
     protected function encryptSensitiveData(): void
     {
         foreach ( $this->getSensitiveDataAttributes() as $attribute ) {
-            if ( ! isset( $this->attributes[ $attribute ] ) || empty( $this->attributes[ $attribute ] ) ) {
+            if ( ! $this->attributeIsPresent( $attribute ) ) {
                 continue;
             }
 
@@ -273,7 +292,7 @@ trait PrivacyByDesign
      */
     protected function decryptSensitiveAttribute( string $attribute ): ?string
     {
-        if ( ! isset( $this->attributes[ $attribute ] ) || empty( $this->attributes[ $attribute ] ) ) {
+        if ( ! $this->attributeIsPresent( $attribute ) ) {
             return null;
         }
 

--- a/src/Compliance/Traits/PrivacyByDesign.php
+++ b/src/Compliance/Traits/PrivacyByDesign.php
@@ -8,6 +8,7 @@ use Exception;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use RuntimeException;
 
 trait PrivacyByDesign
 {
@@ -29,7 +30,13 @@ trait PrivacyByDesign
 
         foreach ( $this->getSensitiveDataAttributes() as $attribute ) {
             if ( isset( $data[ $attribute ] ) ) {
-                $data[ $attribute ] = hash( 'sha256', $data[ $attribute ] . $salt );
+                // Sensitive attributes are encrypted at rest, so toArray()
+                // gave us non-deterministic ciphertext. Hashing that would
+                // produce a different pseudonym each time the row is
+                // re-saved. Decrypt first so the same underlying value
+                // always maps to the same pseudonym.
+                $plain              = $this->decryptSensitiveAttribute( $attribute ) ?? $data[ $attribute ];
+                $data[ $attribute ] = hash( 'sha256', $plain . $salt );
             }
         }
 
@@ -204,18 +211,61 @@ trait PrivacyByDesign
     protected function encryptSensitiveData(): void
     {
         foreach ( $this->getSensitiveDataAttributes() as $attribute ) {
-            if ( isset( $this->attributes[ $attribute ] ) && ! empty( $this->attributes[ $attribute ] ) ) {
-                // Check if the value is already encrypted by attempting to decrypt it
+            if ( ! isset( $this->attributes[ $attribute ] ) || empty( $this->attributes[ $attribute ] ) ) {
+                continue;
+            }
+
+            // Only encrypt values that look confidently like plaintext.
+            // The previous "decrypt-or-encrypt" approach silently
+            // re-encrypted legacy/malformed ciphertext (or values
+            // encrypted under a rotated app key), corrupting the field.
+            // Now: if the stored value parses as a Laravel encrypted
+            // payload AND decrypts cleanly → leave alone. If it parses
+            // as an encrypted payload but fails to decrypt → bail
+            // loudly rather than re-encrypting opaque ciphertext.
+            // Otherwise → treat as plaintext and encrypt.
+            $value = $this->attributes[ $attribute ];
+
+            if ( $this->looksLikeEncryptedPayload( $value ) ) {
                 try {
-                    Crypt::decryptString( $this->attributes[ $attribute ] );
-                    // If decryption succeeds, the value is already encrypted - skip
+                    Crypt::decryptString( $value );
+                    // Already encrypted with the current key — leave it.
                     continue;
                 } catch ( \Illuminate\Contracts\Encryption\DecryptException $e ) {
-                    // Decryption failed, meaning the value is not encrypted yet - proceed to encrypt
-                    $this->attributes[ $attribute ] = Crypt::encryptString( $this->attributes[ $attribute ] );
+                    throw new RuntimeException(
+                        "PrivacyByDesign: refusing to re-encrypt unreadable ciphertext for attribute '{$attribute}' "
+                            . '(legacy payload or rotated app key). Re-encrypt manually after migrating the data.',
+                        0,
+                        $e,
+                    );
                 }
             }
+
+            $this->attributes[ $attribute ] = Crypt::encryptString( $value );
         }
+    }
+
+    /**
+     * Heuristic: does a string look like a Laravel encrypted payload?
+     *
+     * Laravel's Crypt::encryptString returns a base64-encoded JSON
+     * blob with `iv`, `value`, and `mac` keys — recognising that
+     * shape lets us distinguish "real ciphertext that won't decrypt"
+     * from "user-supplied plaintext that happens to contain symbols".
+     */
+    protected function looksLikeEncryptedPayload( string $value ): bool
+    {
+        $decoded = base64_decode( $value, true );
+        if ( false === $decoded ) {
+            return false;
+        }
+
+        $json = json_decode( $decoded, true );
+
+        return is_array( $json )
+            && array_key_exists( 'iv', $json )
+            && array_key_exists( 'value', $json )
+            && array_key_exists( 'mac', $json );
     }
 
     /**

--- a/src/Compliance/Traits/PrivacyByDesign.php
+++ b/src/Compliance/Traits/PrivacyByDesign.php
@@ -1,0 +1,314 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Traits;
+
+use Exception;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+trait PrivacyByDesign
+{
+    /**
+     * Pseudonymize personal data for analytics.
+     *
+     * @return array<string, mixed>
+     */
+    public function pseudonymize(): array
+    {
+        $data = $this->toArray();
+        $salt = config( 'app.key' );
+
+        foreach ( $this->getPersonalDataAttributes() as $attribute ) {
+            if ( isset( $data[ $attribute ] ) ) {
+                $data[ $attribute ] = hash( 'sha256', $data[ $attribute ] . $salt );
+            }
+        }
+
+        foreach ( $this->getSensitiveDataAttributes() as $attribute ) {
+            if ( isset( $data[ $attribute ] ) ) {
+                $data[ $attribute ] = hash( 'sha256', $data[ $attribute ] . $salt );
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Get anonymized copy of the model.
+     *
+     * @return array<string, mixed>
+     */
+    public function anonymize(): array
+    {
+        $data = $this->toArray();
+
+        foreach ( $this->getPersonalDataAttributes() as $attribute ) {
+            if ( isset( $data[ $attribute ] ) ) {
+                $data[ $attribute ] = $this->anonymizeValue( $data[ $attribute ], $attribute );
+            }
+        }
+
+        foreach ( $this->getSensitiveDataAttributes() as $attribute ) {
+            unset( $data[ $attribute ] );
+        }
+
+        return $data;
+    }
+
+    /**
+     * Check if data can be collected for purpose.
+     */
+    public function canCollectFor( string $purpose ): bool
+    {
+        $rules = $this->getMinimizationRules();
+
+        if ( empty( $rules ) ) {
+            return true;
+        }
+
+        return isset( $rules[ $purpose ] ) && ! empty( $rules[ $purpose ]['allowed'] );
+    }
+
+    /**
+     * Get all personal data from this model.
+     *
+     * @return array<string, mixed>
+     */
+    public function getPersonalData(): array
+    {
+        $data = [];
+
+        foreach ( $this->getPersonalDataAttributes() as $attribute ) {
+            if ( isset( $this->attributes[ $attribute ] ) ) {
+                $data[ $attribute ] = $this->getAttribute( $attribute );
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Get all sensitive data from this model.
+     *
+     * @return array<string, mixed>
+     */
+    public function getSensitiveData(): array
+    {
+        $data = [];
+
+        foreach ( $this->getSensitiveDataAttributes() as $attribute ) {
+            if ( isset( $this->attributes[ $attribute ] ) ) {
+                $value              = $this->decryptSensitiveAttribute( $attribute );
+                $data[ $attribute ] = $value ?? $this->getAttribute( $attribute );
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Check if any personal data is present.
+     */
+    public function hasPersonalData(): bool
+    {
+        foreach ( $this->getPersonalDataAttributes() as $attribute ) {
+            if ( ! empty( $this->attributes[ $attribute ] ) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if any sensitive data is present.
+     */
+    public function hasSensitiveData(): bool
+    {
+        foreach ( $this->getSensitiveDataAttributes() as $attribute ) {
+            if ( ! empty( $this->attributes[ $attribute ] ) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Redact personal data (replace with placeholders).
+     */
+    public function redactPersonalData(): void
+    {
+        foreach ( $this->getPersonalDataAttributes() as $attribute ) {
+            if ( isset( $this->attributes[ $attribute ] ) ) {
+                $this->attributes[ $attribute ] = '[REDACTED]';
+            }
+        }
+
+        foreach ( $this->getSensitiveDataAttributes() as $attribute ) {
+            if ( isset( $this->attributes[ $attribute ] ) ) {
+                $this->attributes[ $attribute ] = '[REDACTED]';
+            }
+        }
+    }
+
+    /**
+     * Define which attributes contain personal data.
+     *
+     * @return array<string>
+     */
+    protected function getPersonalDataAttributes(): array
+    {
+        return $this->personalDataAttributes ?? [];
+    }
+
+    /**
+     * Define which attributes are sensitive/special category.
+     *
+     * @return array<string>
+     */
+    protected function getSensitiveDataAttributes(): array
+    {
+        return $this->sensitiveDataAttributes ?? [];
+    }
+
+    /**
+     * Get data minimization rules.
+     *
+     * @return array<string, mixed>
+     */
+    protected function getMinimizationRules(): array
+    {
+        return $this->minimizationRules ?? [];
+    }
+
+    /**
+     * Get retention periods for attributes.
+     *
+     * @return array<string, int|null>
+     */
+    protected function getRetentionPeriods(): array
+    {
+        return $this->retentionPeriods ?? [];
+    }
+
+    /**
+     * Automatically encrypt sensitive attributes.
+     *
+     * Skips encryption for values that are already encrypted to prevent
+     * double-encryption issues.
+     */
+    protected function encryptSensitiveData(): void
+    {
+        foreach ( $this->getSensitiveDataAttributes() as $attribute ) {
+            if ( isset( $this->attributes[ $attribute ] ) && ! empty( $this->attributes[ $attribute ] ) ) {
+                // Check if the value is already encrypted by attempting to decrypt it
+                try {
+                    Crypt::decryptString( $this->attributes[ $attribute ] );
+                    // If decryption succeeds, the value is already encrypted - skip
+                    continue;
+                } catch ( \Illuminate\Contracts\Encryption\DecryptException $e ) {
+                    // Decryption failed, meaning the value is not encrypted yet - proceed to encrypt
+                    $this->attributes[ $attribute ] = Crypt::encryptString( $this->attributes[ $attribute ] );
+                }
+            }
+        }
+    }
+
+    /**
+     * Decrypt a sensitive attribute.
+     */
+    protected function decryptSensitiveAttribute( string $attribute ): ?string
+    {
+        if ( ! isset( $this->attributes[ $attribute ] ) || empty( $this->attributes[ $attribute ] ) ) {
+            return null;
+        }
+
+        try {
+            return Crypt::decryptString( $this->attributes[ $attribute ] );
+        } catch ( Exception $e ) {
+            Log::warning( "Failed to decrypt attribute {$attribute}", [
+                'model' => static::class,
+                'id'    => $this->getKey(),
+            ] );
+
+            return null;
+        }
+    }
+
+    /**
+     * Anonymize a single value.
+     */
+    protected function anonymizeValue( mixed $value, string $attribute ): mixed
+    {
+        if ( null === $value ) {
+            return null;
+        }
+
+        // Check for email pattern
+        if ( filter_var( $value, FILTER_VALIDATE_EMAIL ) ) {
+            return $this->anonymizeEmail( $value );
+        }
+
+        // Check for phone pattern
+        if ( is_string( $value ) && preg_match( '/^[\d\s\-\+\(\)]+$/', $value ) ) {
+            return $this->anonymizePhone( $value );
+        }
+
+        // Default string anonymization
+        if ( is_string( $value ) ) {
+            return Str::mask( $value, '*', 0, max( 1, strlen( $value ) - 2 ) );
+        }
+
+        // For numbers, return a generalized range
+        if ( is_numeric( $value ) ) {
+            $order = pow( 10, max( 0, strlen( (string) (int) $value ) - 1 ) );
+
+            return floor( $value / $order ) * $order;
+        }
+
+        return '[REDACTED]';
+    }
+
+    /**
+     * Anonymize an email address.
+     */
+    protected function anonymizeEmail( string $email ): string
+    {
+        [$local, $domain] = explode( '@', $email );
+
+        return Str::mask( $local, '*', 1 ) . '@' . $domain;
+    }
+
+    /**
+     * Anonymize a phone number.
+     */
+    protected function anonymizePhone( string $phone ): string
+    {
+        $digits = preg_replace( '/[^\d]/', '', $phone );
+
+        return Str::mask( $digits, '*', 0, -4 );
+    }
+
+    /**
+     * Log data access for audit trail.
+     */
+    protected function logDataAccess( string $accessor, string $purpose ): void
+    {
+        if ( ! config( 'artisanpack.compliance.compliance.privacy_by_design.log_data_access', true ) ) {
+            return;
+        }
+
+        Log::info( 'Personal data accessed', [
+            'model'               => static::class,
+            'record_id'           => $this->getKey(),
+            'accessor'            => $accessor,
+            'purpose'             => $purpose,
+            'timestamp'           => now()->toIso8601String(),
+            'personal_attributes' => $this->getPersonalDataAttributes(),
+        ] );
+    }
+}

--- a/src/Compliance/Traits/PrivacyByDesign.php
+++ b/src/Compliance/Traits/PrivacyByDesign.php
@@ -245,6 +245,18 @@ trait PrivacyByDesign
             // Otherwise → treat as plaintext and encrypt.
             $value = $this->attributes[ $attribute ];
 
+            // Crypt::encryptString and looksLikeEncryptedPayload both
+            // require a string (declare(strict_types=1) is on for this
+            // trait). Coerce scalars to string and skip values that
+            // can't be coerced (arrays, objects, resources) rather
+            // than throwing a TypeError mid-save.
+            if ( ! is_string( $value ) ) {
+                if ( ! is_scalar( $value ) ) {
+                    continue;
+                }
+                $value = (string) $value;
+            }
+
             if ( $this->looksLikeEncryptedPayload( $value ) ) {
                 try {
                     Crypt::decryptString( $value );
@@ -296,8 +308,18 @@ trait PrivacyByDesign
             return null;
         }
 
+        $value = $this->attributes[ $attribute ];
+
+        // Skip values that aren't a Laravel encrypted payload at all —
+        // an unsaved model or a redacted placeholder ('[REDACTED]')
+        // would otherwise log a warning on every read despite the
+        // caller already handling the null return gracefully.
+        if ( ! is_string( $value ) || ! $this->looksLikeEncryptedPayload( $value ) ) {
+            return null;
+        }
+
         try {
-            return Crypt::decryptString( $this->attributes[ $attribute ] );
+            return Crypt::decryptString( $value );
         } catch ( Exception $e ) {
             Log::warning( "Failed to decrypt attribute {$attribute}", [
                 'model' => static::class,

--- a/src/Compliance/Traits/PrivacyByDesign.php
+++ b/src/Compliance/Traits/PrivacyByDesign.php
@@ -8,6 +8,7 @@ use Exception;
 use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 use RuntimeException;
 
 trait PrivacyByDesign
@@ -247,12 +248,22 @@ trait PrivacyByDesign
 
             // Crypt::encryptString and looksLikeEncryptedPayload both
             // require a string (declare(strict_types=1) is on for this
-            // trait). Coerce scalars to string and skip values that
-            // can't be coerced (arrays, objects, resources) rather
-            // than throwing a TypeError mid-save.
+            // trait). Coerce scalars to string. Non-scalar values
+            // (arrays, objects, resources) fail CLOSED with an explicit
+            // exception — silently skipping them would leave the
+            // attribute persisted in plaintext, which is the opposite
+            // of what a privacy package should do. Apps storing
+            // structured sensitive data should JSON-encode (or
+            // otherwise serialize) before assigning to the attribute.
             if ( ! is_string( $value ) ) {
                 if ( ! is_scalar( $value ) ) {
-                    continue;
+                    throw new InvalidArgumentException( sprintf(
+                        'PrivacyByDesign: sensitive attribute "%s" on %s holds a non-scalar value (%s); '
+                            . 'serialize it to a string before save (e.g. JSON-encode) so it can be encrypted.',
+                        $attribute,
+                        static::class,
+                        get_debug_type( $value ),
+                    ) );
                 }
                 $value = (string) $value;
             }

--- a/src/Compliance/Traits/PrivacyByDesign.php
+++ b/src/Compliance/Traits/PrivacyByDesign.php
@@ -298,7 +298,7 @@ trait PrivacyByDesign
      */
     protected function logDataAccess( string $accessor, string $purpose ): void
     {
-        if ( ! config( 'artisanpack.compliance.compliance.privacy_by_design.log_data_access', true ) ) {
+        if ( ! config( 'artisanpack.compliance.privacy_by_design.log_data_access', true ) ) {
             return;
         }
 

--- a/src/Compliance/Validation/DataMinimizationValidator.php
+++ b/src/Compliance/Validation/DataMinimizationValidator.php
@@ -153,13 +153,21 @@ class DataMinimizationValidator
      */
     protected function validateFormat( mixed $value, string $format ): bool
     {
+        // Reject non-scalar input up-front. The string-dependent checks
+        // below (strtotime / ctype_*) emit warnings on arrays / objects
+        // rather than returning false, so a non-scalar would slip past
+        // as "valid" without this guard.
+        if ( is_array( $value ) || is_object( $value ) ) {
+            return false;
+        }
+
         return match ( $format ) {
             'email'        => false !== filter_var( $value, FILTER_VALIDATE_EMAIL ),
-            'phone'        => is_string( $value ) && preg_match( '/^[\d\s\-\+\(\)]+$/', $value ),
-            'date'         => false !== strtotime( $value ),
+            'phone'        => is_string( $value ) && (bool) preg_match( '/^[\d\s\-\+\(\)]+$/', $value ),
+            'date'         => is_string( $value ) && false !== strtotime( $value ),
             'numeric'      => is_numeric( $value ),
-            'alpha'        => ctype_alpha( $value ),
-            'alphanumeric' => ctype_alnum( $value ),
+            'alpha'        => is_string( $value ) && ctype_alpha( $value ),
+            'alphanumeric' => is_string( $value ) && ctype_alnum( $value ),
             default        => true,
         };
     }

--- a/src/Compliance/Validation/DataMinimizationValidator.php
+++ b/src/Compliance/Validation/DataMinimizationValidator.php
@@ -1,0 +1,166 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Validation;
+
+use ArtisanPackUI\Compliance\Models\CollectionPolicy;
+
+class DataMinimizationValidator
+{
+    /**
+     * Validate that only necessary data is collected.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function validateCollection( array $data, string $purpose ): ValidationResult
+    {
+        $policy = CollectionPolicy::getForPurpose( $purpose );
+
+        if ( ! $policy ) {
+            return ValidationResult::valid();
+        }
+
+        $errors   = [];
+        $warnings = [];
+
+        // Check for missing required fields
+        $missingRequired = $policy->getMissingRequiredFields( $data );
+        foreach ( $missingRequired as $field ) {
+            $errors[] = "Required field '{$field}' is missing for purpose '{$purpose}'";
+        }
+
+        // Check for prohibited fields
+        $prohibited = $policy->prohibited_fields ?? [];
+        foreach ( array_keys( $data ) as $field ) {
+            if ( in_array( $field, $prohibited ) ) {
+                $errors[] = "Field '{$field}' is prohibited for purpose '{$purpose}'";
+            }
+        }
+
+        // Check for unnecessary fields
+        $allowed = $policy->allowed_fields ?? [];
+        if ( ! empty( $allowed ) ) {
+            foreach ( array_keys( $data ) as $field ) {
+                if ( ! in_array( $field, $allowed ) && ! in_array( $field, $prohibited ) ) {
+                    $warnings[] = "Field '{$field}' may be unnecessary for purpose '{$purpose}'";
+                }
+            }
+        }
+
+        return new ValidationResult(
+            isValid: empty( $errors ),
+            errors: $errors,
+            warnings: $warnings,
+        );
+    }
+
+    /**
+     * Get fields allowed for purpose.
+     *
+     * @return array<string>
+     */
+    public function getAllowedFields( string $purpose ): array
+    {
+        $policy = CollectionPolicy::getForPurpose( $purpose );
+
+        return $policy?->allowed_fields ?? [];
+    }
+
+    /**
+     * Get fields required for purpose.
+     *
+     * @return array<string>
+     */
+    public function getRequiredFields( string $purpose ): array
+    {
+        $policy = CollectionPolicy::getForPurpose( $purpose );
+
+        return $policy?->required_fields ?? [];
+    }
+
+    /**
+     * Check if field is necessary for purpose.
+     */
+    public function isNecessary( string $field, string $purpose ): bool
+    {
+        $policy = CollectionPolicy::getForPurpose( $purpose );
+
+        if ( ! $policy ) {
+            return true; // No policy means all fields allowed
+        }
+
+        // Check if prohibited
+        if ( in_array( $field, $policy->prohibited_fields ?? [] ) ) {
+            return false;
+        }
+
+        // If allowed list is empty, all non-prohibited are necessary
+        if ( empty( $policy->allowed_fields ) ) {
+            return true;
+        }
+
+        // Check if in allowed list
+        return in_array( $field, $policy->allowed_fields );
+    }
+
+    /**
+     * Validate data against minimization rules.
+     *
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $rules
+     *
+     * @return array<string>
+     */
+    public function validate( array $data, array $rules ): array
+    {
+        $errors = [];
+
+        foreach ( $rules as $field => $rule ) {
+            if ( ! isset( $data[ $field ] ) ) {
+                if ( $rule['required'] ?? false ) {
+                    $errors[] = "Required field '{$field}' is missing";
+                }
+
+                continue;
+            }
+
+            $value = $data[ $field ];
+
+            // Check max length
+            if ( isset( $rule['max_length'] ) && is_string( $value ) && strlen( $value ) > $rule['max_length'] ) {
+                $errors[] = "Field '{$field}' exceeds maximum length of {$rule['max_length']}";
+            }
+
+            // Check allowed values
+            if ( isset( $rule['allowed_values'] ) && ! in_array( $value, $rule['allowed_values'] ) ) {
+                $errors[] = "Field '{$field}' has an invalid value";
+            }
+
+            // Check format
+            if ( isset( $rule['format'] ) ) {
+                if ( ! $this->validateFormat( $value, $rule['format'] ) ) {
+                    $errors[] = "Field '{$field}' has an invalid format";
+                }
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Validate a value's format.
+     */
+    protected function validateFormat( mixed $value, string $format ): bool
+    {
+        return match ( $format ) {
+            'email'        => false !== filter_var( $value, FILTER_VALIDATE_EMAIL ),
+            'phone'        => is_string( $value ) && preg_match( '/^[\d\s\-\+\(\)]+$/', $value ),
+            'date'         => false !== strtotime( $value ),
+            'numeric'      => is_numeric( $value ),
+            'alpha'        => ctype_alpha( $value ),
+            'alphanumeric' => ctype_alnum( $value ),
+            default        => true,
+        };
+    }
+}

--- a/src/Compliance/Validation/ValidationResult.php
+++ b/src/Compliance/Validation/ValidationResult.php
@@ -1,0 +1,77 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Compliance\Validation;
+
+class ValidationResult
+{
+    /**
+     * @param  array<string>  $errors
+     * @param  array<string>  $warnings
+     */
+    public function __construct(
+        public readonly bool $isValid,
+        public readonly array $errors = [],
+        public readonly array $warnings = [],
+    ) {
+    }
+
+    /**
+     * Create a valid result.
+     */
+    public static function valid(): self
+    {
+        return new self( isValid: true );
+    }
+
+    /**
+     * Create an invalid result.
+     *
+     * @param  array<string>  $errors
+     */
+    public static function invalid( array $errors ): self
+    {
+        return new self( isValid: false, errors: $errors );
+    }
+
+    /**
+     * Check if there are any errors.
+     */
+    public function hasErrors(): bool
+    {
+        return ! empty( $this->errors );
+    }
+
+    /**
+     * Check if there are any warnings.
+     */
+    public function hasWarnings(): bool
+    {
+        return ! empty( $this->warnings );
+    }
+
+    /**
+     * Get all messages (errors + warnings).
+     *
+     * @return array<string>
+     */
+    public function getAllMessages(): array
+    {
+        return array_merge( $this->errors, $this->warnings );
+    }
+
+    /**
+     * Convert to array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'valid'    => $this->isValid,
+            'errors'   => $this->errors,
+            'warnings' => $this->warnings,
+        ];
+    }
+}

--- a/src/ComplianceServiceProvider.php
+++ b/src/ComplianceServiceProvider.php
@@ -145,11 +145,11 @@ class ComplianceServiceProvider extends ServiceProvider
     {
         $router = $this->app['router'];
 
-        if ( config( 'artisanpack.compliance.compliance.consent.enabled', true ) ) {
+        if ( config( 'artisanpack.compliance.consent.enabled', true ) ) {
             $router->aliasMiddleware( 'check.consent', CheckConsentMiddleware::class );
         }
 
-        if ( config( 'artisanpack.compliance.compliance.minimization.enabled', true ) ) {
+        if ( config( 'artisanpack.compliance.minimization.enabled', true ) ) {
             $router->aliasMiddleware( 'data.minimization', DataMinimizationMiddleware::class );
         }
     }

--- a/src/ComplianceServiceProvider.php
+++ b/src/ComplianceServiceProvider.php
@@ -1,71 +1,239 @@
 <?php
 
-/**
- * Package service provider.
- *
- * Bootstraps the Package by registering services and bindings.
- *
- * @package    ArtisanPack_UI
- * @subpackage Compliance
- *
- * @author     Jacob Martella <me@jacobmartella.com>
- *
- * @since      0.1.0
- */
-
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\Compliance;
 
+use ArtisanPackUI\Compliance\Compliance\Assessment\DpiaService;
+use ArtisanPackUI\Compliance\Compliance\Assessment\ProcessingActivityService;
+use ArtisanPackUI\Compliance\Compliance\Assessment\RiskCalculator;
+use ArtisanPackUI\Compliance\Compliance\Consent\ConsentManager;
+use ArtisanPackUI\Compliance\Compliance\Consent\ConsentPolicyService;
+use ArtisanPackUI\Compliance\Compliance\Consent\CookieConsentHandler;
+use ArtisanPackUI\Compliance\Compliance\Erasure\ErasureService;
+use ArtisanPackUI\Compliance\Compliance\Middleware\CheckConsentMiddleware;
+use ArtisanPackUI\Compliance\Compliance\Middleware\DataMinimizationMiddleware;
+use ArtisanPackUI\Compliance\Compliance\Minimization\AnonymizationEngine;
+use ArtisanPackUI\Compliance\Compliance\Minimization\DataMinimizerService;
+use ArtisanPackUI\Compliance\Compliance\Minimization\PseudonymizationEngine;
+use ArtisanPackUI\Compliance\Compliance\Monitoring\ComplianceMonitor;
+use ArtisanPackUI\Compliance\Compliance\Portability\PortabilityService;
+use ArtisanPackUI\Compliance\Compliance\Reporting\ReportGenerator as ComplianceReportGenerator;
+use ArtisanPackUI\Compliance\Console\Commands\GenerateComplianceReport;
+use ArtisanPackUI\Compliance\Console\Commands\ProcessErasureRequests;
+use ArtisanPackUI\Compliance\Console\Commands\ProcessPortabilityRequests;
+use ArtisanPackUI\Compliance\Console\Commands\PurgeExpiredData;
+use ArtisanPackUI\Compliance\Console\Commands\RunComplianceChecks;
+use ArtisanPackUI\Compliance\Events\ComplianceCheckCompleted;
+use ArtisanPackUI\Compliance\Events\ComplianceViolationDetected;
+use ArtisanPackUI\Compliance\Events\ConsentGranted;
+use ArtisanPackUI\Compliance\Events\ConsentWithdrawn;
+use ArtisanPackUI\Compliance\Events\DataExportCompleted;
+use ArtisanPackUI\Compliance\Events\DataExportRequested;
+use ArtisanPackUI\Compliance\Events\ErasureCompleted;
+use ArtisanPackUI\Compliance\Events\ErasureRequested;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
 
 /**
- * Service provider for the Package.
+ * Service provider for the Compliance package.
  *
- * Bootstraps the Package by registering services and bindings.
- * Extend this class with your package's configuration, migrations,
- * routes, views, and other service registrations as content is
- * extracted from artisanpack-ui/security 1.x.
- *
- * @package    ArtisanPack_UI
- * @subpackage Compliance
- *
- * @since      0.1.0
+ * Wires consent management, data subject rights (erasure + portability),
+ * DPIA + processing activities, data minimization, monitoring, and
+ * reporting. Loads config, migrations, routes, middleware aliases,
+ * compliance event listeners, the dashboard gate, and console commands.
  */
 class ComplianceServiceProvider extends ServiceProvider
 {
     /**
-     * Registers any application services.
-     *
-     * Binds the Package class as a singleton in the container.
-     * Add additional service registrations here.
-     *
-     * @since 0.1.0
-     *
-     * @return void
+     * Register container bindings.
      */
     public function register(): void
     {
-        $this->app->singleton( 'compliance', function ( $app ) {
-            return new Compliance();
+        $this->mergeConfigFrom(
+            __DIR__ . '/../config/artisanpack/compliance.php',
+            'artisanpack.compliance',
+        );
+
+        $this->app->singleton( 'compliance', fn () => new Compliance() );
+
+        $this->registerComplianceServices();
+    }
+
+    /**
+     * Bootstrap package services.
+     */
+    public function boot(): void
+    {
+        $this->publishes( [
+            __DIR__ . '/../config/artisanpack/compliance.php'
+                => config_path( 'artisanpack/compliance.php' ),
+        ], 'compliance-config' );
+
+        if ( ! config( 'artisanpack.compliance.enabled', true ) ) {
+            return;
+        }
+
+        $this->loadMigrationsFrom( __DIR__ . '/../database/migrations' );
+
+        $this->registerComplianceMiddleware();
+
+        if ( $this->app->runningInConsole() ) {
+            $this->commands( [
+                RunComplianceChecks::class,
+                ProcessErasureRequests::class,
+                ProcessPortabilityRequests::class,
+                PurgeExpiredData::class,
+                GenerateComplianceReport::class,
+            ] );
+        }
+
+        $this->registerComplianceEventListeners();
+
+        if ( config( 'artisanpack.compliance.routes.enabled', true ) ) {
+            $this->loadRoutesFrom( __DIR__ . '/../routes/compliance.php' );
+        }
+
+        $this->registerComplianceDashboardGate();
+    }
+
+    /**
+     * Register compliance service singletons.
+     */
+    protected function registerComplianceServices(): void
+    {
+        // Consent management
+        $this->app->singleton( ConsentManager::class, fn () => new ConsentManager() );
+        $this->app->singleton( ConsentPolicyService::class, fn () => new ConsentPolicyService() );
+        $this->app->singleton( CookieConsentHandler::class, fn () => new CookieConsentHandler() );
+
+        // Data minimization
+        $this->app->singleton( AnonymizationEngine::class, fn () => new AnonymizationEngine() );
+        $this->app->singleton( PseudonymizationEngine::class, fn () => new PseudonymizationEngine() );
+        $this->app->singleton( DataMinimizerService::class, function ( $app ): DataMinimizerService {
+            return new DataMinimizerService(
+                $app->make( AnonymizationEngine::class ),
+                $app->make( PseudonymizationEngine::class ),
+            );
+        } );
+
+        // Data subject rights
+        $this->app->singleton( ErasureService::class, fn () => new ErasureService() );
+        $this->app->singleton( PortabilityService::class, fn () => new PortabilityService() );
+
+        // DPIA / processing activities
+        $this->app->singleton( RiskCalculator::class, fn () => new RiskCalculator() );
+        $this->app->singleton( ProcessingActivityService::class, fn () => new ProcessingActivityService() );
+        $this->app->singleton( DpiaService::class, function ( $app ): DpiaService {
+            return new DpiaService(
+                $app->make( RiskCalculator::class ),
+                $app->make( ProcessingActivityService::class ),
+            );
+        } );
+
+        // Monitoring + reporting
+        $this->app->singleton( ComplianceMonitor::class, fn () => new ComplianceMonitor() );
+        $this->app->singleton( ComplianceReportGenerator::class, fn () => new ComplianceReportGenerator() );
+    }
+
+    /**
+     * Register compliance middleware aliases (gated on per-domain config).
+     */
+    protected function registerComplianceMiddleware(): void
+    {
+        $router = $this->app['router'];
+
+        if ( config( 'artisanpack.compliance.compliance.consent.enabled', true ) ) {
+            $router->aliasMiddleware( 'check.consent', CheckConsentMiddleware::class );
+        }
+
+        if ( config( 'artisanpack.compliance.compliance.minimization.enabled', true ) ) {
+            $router->aliasMiddleware( 'data.minimization', DataMinimizationMiddleware::class );
+        }
+    }
+
+    /**
+     * Register compliance event listeners — log every consent /
+     * erasure / data-export / compliance-check / violation event so
+     * apps get an out-of-the-box audit trail without wiring listeners
+     * themselves.
+     */
+    protected function registerComplianceEventListeners(): void
+    {
+        Event::listen( ConsentGranted::class, function ( $event ): void {
+            Log::info( 'Consent granted', [
+                'user_id'   => $event->consentRecord->user_id,
+                'policy_id' => $event->consentRecord->consent_policy_id,
+            ] );
+        } );
+
+        Event::listen( ConsentWithdrawn::class, function ( $event ): void {
+            Log::info( 'Consent withdrawn', [
+                'user_id'   => $event->consentRecord->user_id,
+                'policy_id' => $event->consentRecord->consent_policy_id,
+            ] );
+        } );
+
+        Event::listen( ErasureRequested::class, function ( $event ): void {
+            Log::info( 'Erasure requested', [
+                'request_number' => $event->request->request_number,
+                'user_id'        => $event->request->user_id,
+            ] );
+        } );
+
+        Event::listen( ErasureCompleted::class, function ( $event ): void {
+            Log::info( 'Erasure completed', [
+                'request_number' => $event->request->request_number,
+                'user_id'        => $event->request->user_id,
+            ] );
+        } );
+
+        Event::listen( DataExportRequested::class, function ( $event ): void {
+            Log::info( 'Data export requested', [
+                'request_number' => $event->request->request_number,
+                'user_id'        => $event->request->user_id,
+            ] );
+        } );
+
+        Event::listen( DataExportCompleted::class, function ( $event ): void {
+            Log::info( 'Data export completed', [
+                'request_number' => $event->request->request_number,
+                'user_id'        => $event->request->user_id,
+            ] );
+        } );
+
+        Event::listen( ComplianceCheckCompleted::class, function ( $event ): void {
+            if ( ! $event->result->passed ) {
+                Log::warning( 'Compliance check failed', [
+                    'check'   => $event->result->checkName,
+                    'message' => $event->result->message,
+                ] );
+            }
+        } );
+
+        Event::listen( ComplianceViolationDetected::class, function ( $event ): void {
+            Log::error( 'Compliance violation detected', [
+                'violation_number' => $event->violation->violation_number,
+                'severity'         => $event->violation->severity,
+                'category'         => $event->violation->category,
+                'title'            => $event->violation->title,
+            ] );
         } );
     }
 
     /**
-     * Bootstraps any application services.
+     * Default-deny gate for compliance dashboard access. Apps should
+     * override in their AuthServiceProvider:
      *
-     * Add package bootstrapping here such as:
-     * - Configuration publishing: $this->publishes([...])
-     * - Migration loading: $this->loadMigrationsFrom(...)
-     * - View loading: $this->loadViewsFrom(...)
-     * - Route loading: $this->loadRoutesFrom(...)
-     *
-     * @since 0.1.0
-     *
-     * @return void
+     *   Gate::define('viewComplianceDashboard',
+     *       fn ($user) => $user->hasRole('compliance-officer'));
      */
-    public function boot(): void
+    protected function registerComplianceDashboardGate(): void
     {
-        // Add your package bootstrapping here
+        if ( ! Gate::has( 'viewComplianceDashboard' ) ) {
+            Gate::define( 'viewComplianceDashboard', fn ( $user ) => false);
+        }
     }
 }

--- a/src/ComplianceServiceProvider.php
+++ b/src/ComplianceServiceProvider.php
@@ -205,7 +205,7 @@ class ComplianceServiceProvider extends ServiceProvider
         } );
 
         Event::listen( ComplianceCheckCompleted::class, function ( $event ): void {
-            if ( ! $event->result->passed ) {
+            if ( $event->result->isFailed() ) {
                 Log::warning( 'Compliance check failed', [
                     'check'   => $event->result->checkName,
                     'message' => $event->result->message,

--- a/src/Console/Commands/GenerateComplianceReport.php
+++ b/src/Console/Commands/GenerateComplianceReport.php
@@ -1,0 +1,57 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Console\Commands;
+
+use ArtisanPackUI\Compliance\Compliance\Reporting\ReportGenerator;
+use Exception;
+use Illuminate\Console\Command;
+
+class GenerateComplianceReport extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'compliance:report
+                            {type=compliance_status : Report type to generate}
+                            {--format=json : Output format (json, html, csv)}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate a compliance report';
+
+    public function __construct( protected ReportGenerator $reportGenerator )
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $type   = $this->argument( 'type' );
+        $format = $this->option( 'format' );
+
+        $this->info( "Generating {$type} report..." );
+
+        try {
+            $report = $this->reportGenerator->generate( $type );
+            $path   = $this->reportGenerator->export( $report, $format );
+
+            $this->info( "Report generated: {$path}" );
+
+            return 0;
+        } catch ( Exception $e ) {
+            $this->error( "Failed to generate report: {$e->getMessage()}" );
+
+            return 1;
+        }
+    }
+}

--- a/src/Console/Commands/ProcessErasureRequests.php
+++ b/src/Console/Commands/ProcessErasureRequests.php
@@ -1,0 +1,110 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Console\Commands;
+
+use ArtisanPackUI\Compliance\Compliance\Erasure\ErasureService;
+use ArtisanPackUI\Compliance\Models\ErasureRequest;
+use Exception;
+use Illuminate\Console\Command;
+
+class ProcessErasureRequests extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'compliance:process-erasure
+                            {--request= : Process a specific request}
+                            {--limit=10 : Maximum requests to process}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Process pending erasure requests';
+
+    public function __construct( protected ErasureService $erasureService )
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $requestNumber = $this->option( 'request' );
+        $limit         = (int) $this->option( 'limit' );
+
+        if ( $requestNumber ) {
+            $request = ErasureRequest::where( 'request_number', $requestNumber )->first();
+
+            if ( ! $request ) {
+                $this->error( "Request {$requestNumber} not found" );
+
+                return 1;
+            }
+
+            return $this->processRequest( $request ) ? 0 : 1;
+        }
+
+        $requests = ErasureRequest::where( 'status', 'approved' )
+            ->orderBy( 'created_at' )
+            ->limit( $limit )
+            ->get();
+
+        if ( $requests->isEmpty() ) {
+            $this->info( 'No pending erasure requests to process' );
+
+            return 0;
+        }
+
+        $this->info( "Processing {$requests->count()} erasure request(s)..." );
+
+        $processed = 0;
+        $failed    = 0;
+
+        foreach ( $requests as $request ) {
+            if ( $this->processRequest( $request ) ) {
+                $processed++;
+            } else {
+                $failed++;
+            }
+        }
+
+        $this->newLine();
+        $this->info( "Processed: {$processed}, Failed: {$failed}" );
+
+        return $failed > 0 ? 1 : 0;
+    }
+
+    /**
+     * Process a single request.
+     */
+    protected function processRequest( ErasureRequest $request ): bool
+    {
+        $this->line( "Processing {$request->request_number}..." );
+
+        try {
+            $result = $this->erasureService->processRequest( $request );
+
+            if ( 'completed' === $result->status ) {
+                $this->info( "  [COMPLETED] {$request->request_number}" );
+
+                return true;
+            } else {
+                $this->warn( "  [PARTIAL] {$request->request_number} - Some handlers failed" );
+
+                return true;
+            }
+        } catch ( Exception $e ) {
+            $this->error( "  [FAILED] {$request->request_number}: {$e->getMessage()}" );
+
+            return false;
+        }
+    }
+}

--- a/src/Console/Commands/ProcessPortabilityRequests.php
+++ b/src/Console/Commands/ProcessPortabilityRequests.php
@@ -1,0 +1,123 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Console\Commands;
+
+use ArtisanPackUI\Compliance\Compliance\Portability\PortabilityService;
+use ArtisanPackUI\Compliance\Models\PortabilityRequest;
+use Exception;
+use Illuminate\Console\Command;
+
+class ProcessPortabilityRequests extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'compliance:process-exports
+                            {--request= : Process a specific request}
+                            {--limit=10 : Maximum requests to process}
+                            {--cleanup : Cleanup expired exports}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Process pending data portability/export requests';
+
+    public function __construct( protected PortabilityService $portabilityService )
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        if ( $this->option( 'cleanup' ) ) {
+            return $this->cleanupExpired();
+        }
+
+        $requestNumber = $this->option( 'request' );
+        $limit         = (int) $this->option( 'limit' );
+
+        if ( $requestNumber ) {
+            $request = PortabilityRequest::where( 'request_number', $requestNumber )->first();
+
+            if ( ! $request ) {
+                $this->error( "Request {$requestNumber} not found" );
+
+                return 1;
+            }
+
+            return $this->processRequest( $request ) ? 0 : 1;
+        }
+
+        $requests = PortabilityRequest::pending()
+            ->orderBy( 'created_at' )
+            ->limit( $limit )
+            ->get();
+
+        if ( $requests->isEmpty() ) {
+            $this->info( 'No pending portability requests to process' );
+
+            return 0;
+        }
+
+        $this->info( "Processing {$requests->count()} portability request(s)..." );
+
+        $processed = 0;
+        $failed    = 0;
+
+        foreach ( $requests as $request ) {
+            if ( $this->processRequest( $request ) ) {
+                $processed++;
+            } else {
+                $failed++;
+            }
+        }
+
+        $this->newLine();
+        $this->info( "Processed: {$processed}, Failed: {$failed}" );
+
+        return $failed > 0 ? 1 : 0;
+    }
+
+    /**
+     * Process a single request.
+     */
+    protected function processRequest( PortabilityRequest $request ): bool
+    {
+        $this->line( "Processing {$request->request_number}..." );
+
+        try {
+            $result = $this->portabilityService->processRequest( $request );
+
+            $this->info( "  [COMPLETED] {$request->request_number} - File: {$result->file_path}" );
+
+            return true;
+        } catch ( Exception $e ) {
+            $this->error( "  [FAILED] {$request->request_number}: {$e->getMessage()}" );
+
+            return false;
+        }
+    }
+
+    /**
+     * Cleanup expired exports.
+     */
+    protected function cleanupExpired(): int
+    {
+        $this->info( 'Cleaning up expired exports...' );
+
+        $count = $this->portabilityService->cleanupExpired();
+
+        $this->info( "Cleaned up {$count} expired export(s)" );
+
+        return 0;
+    }
+}

--- a/src/Console/Commands/PurgeExpiredData.php
+++ b/src/Console/Commands/PurgeExpiredData.php
@@ -1,0 +1,113 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Console\Commands;
+
+use ArtisanPackUI\Compliance\Compliance\Minimization\DataMinimizerService;
+use ArtisanPackUI\Compliance\Models\RetentionPolicy;
+use Illuminate\Console\Command;
+
+class PurgeExpiredData extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'compliance:purge-expired
+                            {--dry-run : Show what would be purged without actually purging}
+                            {--policy= : Only purge for a specific policy}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Purge data that has exceeded retention periods';
+
+    public function __construct( protected DataMinimizerService $minimizer )
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $dryRun     = $this->option( 'dry-run' );
+        $policyName = $this->option( 'policy' );
+
+        if ( $dryRun ) {
+            $this->warn( 'Running in dry-run mode - no data will be deleted' );
+        }
+
+        $policies = RetentionPolicy::active();
+
+        if ( $policyName ) {
+            $policies = $policies->where( 'name', $policyName );
+        }
+
+        $policies = $policies->get();
+
+        if ( $policies->isEmpty() ) {
+            $this->info( 'No active retention policies found' );
+
+            return 0;
+        }
+
+        $totalPurged = 0;
+
+        foreach ( $policies as $policy ) {
+            if ( ! $policy->model_class || ! class_exists( $policy->model_class ) ) {
+                $this->warn( "Skipping policy '{$policy->name}' - invalid model class" );
+
+                continue;
+            }
+
+            $this->line( "Processing policy: {$policy->name}" );
+
+            if ( $dryRun ) {
+                // Dry-run is informational, so a TOCTOU gap between the
+                // count and the (skipped) purge is fine here.
+                $count = $this->minimizer->getExpiredData( $policy->model_class )->count();
+
+                if ( 0 === $count ) {
+                    $this->info( '  No expired data found' );
+
+                    continue;
+                }
+
+                $this->info( "  Would purge {$count} record(s)" );
+
+                continue;
+            }
+
+            // Non-dry-run path: trust purgeExpiredData's return value
+            // for both reporting and the running total. Pre-counting
+            // and then deleting separately could mismatch when records
+            // expire during the gap.
+            $purged = $this->minimizer->purgeExpiredData( $policy->model_class );
+
+            if ( 0 === $purged ) {
+                $this->info( '  No expired data found' );
+
+                continue;
+            }
+
+            $this->info( "  Purged {$purged} record(s)" );
+            $totalPurged += $purged;
+        }
+
+        $this->newLine();
+
+        if ( $dryRun ) {
+            $this->info( 'Dry run complete. Run without --dry-run to actually purge data.' );
+        } else {
+            $this->info( "Total records purged: {$totalPurged}" );
+        }
+
+        return 0;
+    }
+}

--- a/src/Console/Commands/RunComplianceChecks.php
+++ b/src/Console/Commands/RunComplianceChecks.php
@@ -1,0 +1,111 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Console\Commands;
+
+use ArtisanPackUI\Compliance\Compliance\Monitoring\ComplianceMonitor;
+use Illuminate\Console\Command;
+
+class RunComplianceChecks extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'compliance:check
+                            {--check= : Run a specific check}
+                            {--category= : Run checks for a specific category}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Run compliance checks and generate violations';
+
+    public function __construct( protected ComplianceMonitor $monitor )
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $checkName = $this->option( 'check' );
+        $category  = $this->option( 'category' );
+
+        if ( $checkName ) {
+            $this->info( "Running compliance check: {$checkName}" );
+            $result = $this->monitor->runCheck( $checkName );
+
+            if ( ! $result ) {
+                $this->error( "Check '{$checkName}' not found or disabled" );
+
+                return 1;
+            }
+
+            $this->displayResult( $checkName, $result );
+
+            return $result->isFailed() ? 1 : 0;
+        }
+
+        if ( $category ) {
+            $this->info( "Running compliance checks for category: {$category}" );
+            $results = $this->monitor->runChecksByCategory( $category );
+        } else {
+            $this->info( 'Running all compliance checks...' );
+            $results = $this->monitor->runAllChecks();
+        }
+
+        $failed = 0;
+        foreach ( $results as $name => $result ) {
+            $this->displayResult( $name, $result );
+            if ( $result->isFailed() ) {
+                $failed++;
+            }
+        }
+
+        $this->newLine();
+        $score = $this->monitor->getCurrentScore();
+        $this->info( "Overall Compliance Score: {$score?->overall_score}% (Grade: {$score?->getGrade()})" );
+
+        if ( $failed > 0 ) {
+            $this->error( "{$failed} check(s) failed" );
+
+            return 1;
+        }
+
+        $this->info( 'All checks passed!' );
+
+        return 0;
+    }
+
+    /**
+     * Display check result.
+     */
+    protected function displayResult( string $name, $result ): void
+    {
+        $status = match ( $result->status ) {
+            'passed'  => '<fg=green>PASSED</>',
+            'failed'  => '<fg=red>FAILED</>',
+            'warning' => '<fg=yellow>WARNING</>',
+            default   => '<fg=gray>ERROR</>',
+        };
+
+        $score = null !== $result->score ? number_format( $result->score, 1 ) . '%' : 'N/A';
+
+        $this->line( "  [{$status}] {$name} - Score: {$score}" );
+
+        if ( $result->violations_found > 0 ) {
+            $this->line( "    <fg=red>Violations: {$result->violations_found}</>" );
+        }
+
+        if ( $result->warnings_found > 0 ) {
+            $this->line( "    <fg=yellow>Warnings: {$result->warnings_found}</>" );
+        }
+    }
+}

--- a/src/Events/ComplianceCheckCompleted.php
+++ b/src/Events/ComplianceCheckCompleted.php
@@ -1,0 +1,19 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Events;
+
+use ArtisanPackUI\Compliance\Models\ComplianceCheckResult;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ComplianceCheckCompleted
+{
+    use Dispatchable;
+use SerializesModels;
+
+    public function __construct( public ComplianceCheckResult $result )
+    {
+    }
+}

--- a/src/Events/ComplianceViolationDetected.php
+++ b/src/Events/ComplianceViolationDetected.php
@@ -1,0 +1,19 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Events;
+
+use ArtisanPackUI\Compliance\Models\ComplianceViolation;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ComplianceViolationDetected
+{
+    use Dispatchable;
+use SerializesModels;
+
+    public function __construct( public ComplianceViolation $violation )
+    {
+    }
+}

--- a/src/Events/ConsentGranted.php
+++ b/src/Events/ConsentGranted.php
@@ -1,0 +1,19 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Events;
+
+use ArtisanPackUI\Compliance\Models\ConsentRecord;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ConsentGranted
+{
+    use Dispatchable;
+use SerializesModels;
+
+    public function __construct( public ConsentRecord $consent )
+    {
+    }
+}

--- a/src/Events/ConsentWithdrawn.php
+++ b/src/Events/ConsentWithdrawn.php
@@ -1,0 +1,19 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Events;
+
+use ArtisanPackUI\Compliance\Models\ConsentRecord;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ConsentWithdrawn
+{
+    use Dispatchable;
+use SerializesModels;
+
+    public function __construct( public ConsentRecord $consent )
+    {
+    }
+}

--- a/src/Events/DataExportCompleted.php
+++ b/src/Events/DataExportCompleted.php
@@ -1,0 +1,19 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Events;
+
+use ArtisanPackUI\Compliance\Models\PortabilityRequest;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class DataExportCompleted
+{
+    use Dispatchable;
+use SerializesModels;
+
+    public function __construct( public PortabilityRequest $request )
+    {
+    }
+}

--- a/src/Events/DataExportRequested.php
+++ b/src/Events/DataExportRequested.php
@@ -1,0 +1,19 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Events;
+
+use ArtisanPackUI\Compliance\Models\PortabilityRequest;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class DataExportRequested
+{
+    use Dispatchable;
+use SerializesModels;
+
+    public function __construct( public PortabilityRequest $request )
+    {
+    }
+}

--- a/src/Events/ErasureCompleted.php
+++ b/src/Events/ErasureCompleted.php
@@ -1,0 +1,19 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Events;
+
+use ArtisanPackUI\Compliance\Models\ErasureRequest;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ErasureCompleted
+{
+    use Dispatchable;
+use SerializesModels;
+
+    public function __construct( public ErasureRequest $request )
+    {
+    }
+}

--- a/src/Events/ErasureRequested.php
+++ b/src/Events/ErasureRequested.php
@@ -1,0 +1,19 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Events;
+
+use ArtisanPackUI\Compliance\Models\ErasureRequest;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ErasureRequested
+{
+    use Dispatchable;
+use SerializesModels;
+
+    public function __construct( public ErasureRequest $request )
+    {
+    }
+}

--- a/src/Http/Controllers/Compliance/ComplianceDashboardController.php
+++ b/src/Http/Controllers/Compliance/ComplianceDashboardController.php
@@ -301,13 +301,9 @@ class ComplianceDashboardController extends Controller
             'consentRecords as withdrawn_count' => fn ( $q ) => $q->where( 'status', 'withdrawn' ),
         ] )->get();
 
-        // ConsentManager::grant() persists the grant time via the model
-        // timestamps (created_at), not granted_at — bucket the trend by
-        // created_at so this reports actual grant counts rather than
-        // silently undercounting / breaking on the missing column.
-        $consentTrend = ConsentRecord::selectRaw( 'DATE(created_at) as date, COUNT(*) as count' )
+        $consentTrend = ConsentRecord::selectRaw( 'DATE(granted_at) as date, COUNT(*) as count' )
             ->where( 'status', 'granted' )
-            ->where( 'created_at', '>=', now()->subDays( 30 ) )
+            ->where( 'granted_at', '>=', now()->subDays( 30 ) )
             ->groupBy( 'date' )
             ->orderBy( 'date' )
             ->get();

--- a/src/Http/Controllers/Compliance/ComplianceDashboardController.php
+++ b/src/Http/Controllers/Compliance/ComplianceDashboardController.php
@@ -134,7 +134,7 @@ class ComplianceDashboardController extends Controller
         }
 
         $violations = $query->orderBy( 'created_at', 'desc' )
-            ->paginate( $request->input( 'per_page', 20 ) );
+            ->paginate( max( 1, min( (int) $request->input( 'per_page', 20 ), 100 ) ) );
 
         return response()->json( [
             'success' => true,
@@ -301,9 +301,13 @@ class ComplianceDashboardController extends Controller
             'consentRecords as withdrawn_count' => fn ( $q ) => $q->where( 'status', 'withdrawn' ),
         ] )->get();
 
-        $consentTrend = ConsentRecord::selectRaw( 'DATE(granted_at) as date, COUNT(*) as count' )
+        // ConsentManager::grant() persists the grant time via the model
+        // timestamps (created_at), not granted_at — bucket the trend by
+        // created_at so this reports actual grant counts rather than
+        // silently undercounting / breaking on the missing column.
+        $consentTrend = ConsentRecord::selectRaw( 'DATE(created_at) as date, COUNT(*) as count' )
             ->where( 'status', 'granted' )
-            ->where( 'granted_at', '>=', now()->subDays( 30 ) )
+            ->where( 'created_at', '>=', now()->subDays( 30 ) )
             ->groupBy( 'date' )
             ->orderBy( 'date' )
             ->get();
@@ -335,7 +339,7 @@ class ComplianceDashboardController extends Controller
     {
         $assessments = DataProtectionAssessment::with( 'processingActivity' )
             ->orderBy( 'created_at', 'desc' )
-            ->paginate( $request->input( 'per_page', 20 ) );
+            ->paginate( max( 1, min( (int) $request->input( 'per_page', 20 ), 100 ) ) );
 
         return response()->json( [
             'success' => true,
@@ -367,7 +371,7 @@ class ComplianceDashboardController extends Controller
     public function reports( Request $request ): JsonResponse
     {
         $reports = ScheduledComplianceReport::orderBy( 'created_at', 'desc' )
-            ->paginate( $request->input( 'per_page', 20 ) );
+            ->paginate( max( 1, min( (int) $request->input( 'per_page', 20 ), 100 ) ) );
 
         return response()->json( [
             'success' => true,

--- a/src/Http/Controllers/Compliance/ComplianceDashboardController.php
+++ b/src/Http/Controllers/Compliance/ComplianceDashboardController.php
@@ -1,0 +1,494 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Http\Controllers\Compliance;
+
+use ArtisanPackUI\Compliance\Compliance\Monitoring\ComplianceMonitor;
+use ArtisanPackUI\Compliance\Compliance\Reporting\ReportGenerator;
+use ArtisanPackUI\Compliance\Models\ComplianceCheckResult;
+use ArtisanPackUI\Compliance\Models\ComplianceScore;
+use ArtisanPackUI\Compliance\Models\ComplianceViolation;
+use ArtisanPackUI\Compliance\Models\ConsentPolicy;
+use ArtisanPackUI\Compliance\Models\ConsentRecord;
+use ArtisanPackUI\Compliance\Models\DataProtectionAssessment;
+use ArtisanPackUI\Compliance\Models\ErasureRequest;
+use ArtisanPackUI\Compliance\Models\PortabilityRequest;
+use ArtisanPackUI\Compliance\Models\ScheduledComplianceReport;
+use Exception;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class ComplianceDashboardController extends Controller
+{
+    public function __construct(
+        protected ComplianceMonitor $monitor,
+        protected ReportGenerator $reportGenerator,
+    ) {
+    }
+
+    /**
+     * Display the compliance dashboard overview.
+     */
+    public function index( Request $request ): JsonResponse
+    {
+        // Get overall compliance score
+        $latestScore = ComplianceScore::latest( 'calculated_at' )->first();
+
+        // Get violation statistics
+        $violationStats = [
+            'total'    => ComplianceViolation::count(),
+            'open'     => ComplianceViolation::open()->count(),
+            'critical' => ComplianceViolation::open()->where( 'severity', 'critical' )->count(),
+            'high'     => ComplianceViolation::open()->where( 'severity', 'high' )->count(),
+            'medium'   => ComplianceViolation::open()->where( 'severity', 'medium' )->count(),
+            'low'      => ComplianceViolation::open()->where( 'severity', 'low' )->count(),
+        ];
+
+        // Get DSR statistics
+        $dsrStats = [
+            'erasure' => [
+                'pending'       => ErasureRequest::where( 'status', 'pending' )->count(),
+                'processing'    => ErasureRequest::where( 'status', 'processing' )->count(),
+                'completed_30d' => ErasureRequest::where( 'status', 'completed' )
+                    ->where( 'completed_at', '>=', now()->subDays( 30 ) )
+                    ->count(),
+            ],
+            'portability' => [
+                'pending'       => PortabilityRequest::where( 'status', 'pending' )->count(),
+                'processing'    => PortabilityRequest::where( 'status', 'processing' )->count(),
+                'completed_30d' => PortabilityRequest::where( 'status', 'completed' )
+                    ->where( 'completed_at', '>=', now()->subDays( 30 ) )
+                    ->count(),
+            ],
+        ];
+
+        // Get consent statistics
+        $consentStats = [
+            'active_policies' => ConsentPolicy::active()->count(),
+            'total_consents'  => ConsentRecord::where( 'status', 'granted' )->count(),
+            'consent_rate'    => $this->calculateConsentRate(),
+        ];
+
+        // Get DPIA statistics
+        $dpiaStats = [
+            'total'     => DataProtectionAssessment::count(),
+            'pending'   => DataProtectionAssessment::where( 'status', 'pending' )->count(),
+            'in_review' => DataProtectionAssessment::where( 'status', 'in_review' )->count(),
+            'high_risk' => DataProtectionAssessment::where( 'overall_risk_level', 'high' )->count(),
+        ];
+
+        // Get recent check results
+        $recentChecks = ComplianceCheckResult::with( 'violation' )
+            ->orderBy( 'checked_at', 'desc' )
+            ->limit( 10 )
+            ->get()
+            ->map( fn ( $check ) => [
+                'check_name' => $check->check_name,
+                'category'   => $check->category,
+                'passed'     => $check->passed,
+                'checked_at' => $check->checked_at->toIso8601String(),
+            ] );
+
+        return response()->json( [
+            'success' => true,
+            'data'    => [
+                'compliance_score' => $latestScore ? [
+                    'overall'         => $latestScore->overall_score,
+                    'category_scores' => $latestScore->category_scores,
+                    'calculated_at'   => $latestScore->calculated_at->toIso8601String(),
+                ] : null,
+                'violations'    => $violationStats,
+                'dsr'           => $dsrStats,
+                'consent'       => $consentStats,
+                'dpia'          => $dpiaStats,
+                'recent_checks' => $recentChecks,
+            ],
+        ] );
+    }
+
+    /**
+     * List all compliance violations.
+     */
+    public function violations( Request $request ): JsonResponse
+    {
+        $query = ComplianceViolation::query();
+
+        // Filter by status
+        if ( $request->has( 'status' ) ) {
+            $query->where( 'status', $request->input( 'status' ) );
+        }
+
+        // Filter by severity
+        if ( $request->has( 'severity' ) ) {
+            $query->where( 'severity', $request->input( 'severity' ) );
+        }
+
+        // Filter by category
+        if ( $request->has( 'category' ) ) {
+            $query->where( 'category', $request->input( 'category' ) );
+        }
+
+        $violations = $query->orderBy( 'created_at', 'desc' )
+            ->paginate( $request->input( 'per_page', 20 ) );
+
+        return response()->json( [
+            'success' => true,
+            'data'    => [
+                'violations' => $violations->through( fn ( $v ) => [
+                    'id'                   => $v->id,
+                    'violation_number'     => $v->violation_number,
+                    'title'                => $v->title,
+                    'severity'             => $v->severity,
+                    'category'             => $v->category,
+                    'status'               => $v->status,
+                    'remediation_deadline' => $v->remediation_deadline?->toIso8601String(),
+                    'created_at'           => $v->created_at->toIso8601String(),
+                ] ),
+                'pagination' => [
+                    'current_page' => $violations->currentPage(),
+                    'last_page'    => $violations->lastPage(),
+                    'per_page'     => $violations->perPage(),
+                    'total'        => $violations->total(),
+                ],
+            ],
+        ] );
+    }
+
+    /**
+     * Show a specific violation.
+     */
+    public function showViolation( ComplianceViolation $violation ): JsonResponse
+    {
+        return response()->json( [
+            'success' => true,
+            'data'    => [
+                'violation' => [
+                    'id'                   => $violation->id,
+                    'violation_number'     => $violation->violation_number,
+                    'title'                => $violation->title,
+                    'description'          => $violation->description,
+                    'severity'             => $violation->severity,
+                    'category'             => $violation->category,
+                    'status'               => $violation->status,
+                    'source'               => $violation->source,
+                    'affected_data'        => $violation->affected_data,
+                    'remediation_steps'    => $violation->remediation_steps,
+                    'remediation_deadline' => $violation->remediation_deadline?->toIso8601String(),
+                    'resolved_at'          => $violation->resolved_at?->toIso8601String(),
+                    'resolution_notes'     => $violation->resolution_notes,
+                    'created_at'           => $violation->created_at->toIso8601String(),
+                ],
+            ],
+        ] );
+    }
+
+    /**
+     * Resolve a violation.
+     */
+    public function resolveViolation( Request $request, ComplianceViolation $violation ): JsonResponse
+    {
+        $validated = $request->validate( [
+            'resolution_notes'     => 'required|string|max:2000',
+            'remediation_evidence' => 'nullable|array',
+        ] );
+
+        if ( 'resolved' === $violation->status ) {
+            return response()->json( [
+                'success' => false,
+                'message' => 'This violation is already resolved.',
+            ], 422 );
+        }
+
+        $violation->update( [
+            'status'               => 'resolved',
+            'resolved_at'          => now(),
+            'resolved_by'          => $request->user()?->id,
+            'resolution_notes'     => $validated['resolution_notes'],
+            'remediation_evidence' => $validated['remediation_evidence'] ?? null,
+        ] );
+
+        return response()->json( [
+            'success' => true,
+            'message' => 'Violation marked as resolved.',
+            'data'    => [
+                'violation' => [
+                    'violation_number' => $violation->violation_number,
+                    'status'           => $violation->status,
+                    'resolved_at'      => $violation->resolved_at->toIso8601String(),
+                ],
+            ],
+        ] );
+    }
+
+    /**
+     * List all DSR requests (erasure and portability).
+     */
+    public function dsrRequests( Request $request ): JsonResponse
+    {
+        $type = $request->input( 'type', 'all' );
+
+        $data = [];
+
+        if ( 'all' === $type || 'erasure' === $type ) {
+            $erasureQuery = ErasureRequest::with( 'user:id,name,email' );
+
+            if ( $request->has( 'status' ) ) {
+                $erasureQuery->where( 'status', $request->input( 'status' ) );
+            }
+
+            $data['erasure_requests'] = $erasureQuery
+                ->orderBy( 'created_at', 'desc' )
+                ->limit( 50 )
+                ->get()
+                ->map( fn ( $r ) => [
+                    'id'             => $r->id,
+                    'request_number' => $r->request_number,
+                    'user'           => $r->user ? [
+                        'id'    => $r->user->id,
+                        'name'  => $r->user->name,
+                        'email' => $r->user->email,
+                    ] : null,
+                    'status'       => $r->status,
+                    'scope'        => $r->scope,
+                    'scheduled_at' => $r->scheduled_at?->toIso8601String(),
+                    'created_at'   => $r->created_at->toIso8601String(),
+                ] );
+        }
+
+        if ( 'all' === $type || 'portability' === $type ) {
+            $portabilityQuery = PortabilityRequest::with( 'user:id,name,email' );
+
+            if ( $request->has( 'status' ) ) {
+                $portabilityQuery->where( 'status', $request->input( 'status' ) );
+            }
+
+            $data['portability_requests'] = $portabilityQuery
+                ->orderBy( 'created_at', 'desc' )
+                ->limit( 50 )
+                ->get()
+                ->map( fn ( $r ) => [
+                    'id'             => $r->id,
+                    'request_number' => $r->request_number,
+                    'user'           => $r->user ? [
+                        'id'    => $r->user->id,
+                        'name'  => $r->user->name,
+                        'email' => $r->user->email,
+                    ] : null,
+                    'status'     => $r->status,
+                    'format'     => $r->format,
+                    'created_at' => $r->created_at->toIso8601String(),
+                ] );
+        }
+
+        return response()->json( [
+            'success' => true,
+            'data'    => $data,
+        ] );
+    }
+
+    /**
+     * Get consent overview.
+     */
+    public function consentOverview( Request $request ): JsonResponse
+    {
+        $policies = ConsentPolicy::withCount( [
+            'consentRecords as granted_count'   => fn ( $q ) => $q->where( 'status', 'granted' ),
+            'consentRecords as withdrawn_count' => fn ( $q ) => $q->where( 'status', 'withdrawn' ),
+        ] )->get();
+
+        $consentTrend = ConsentRecord::selectRaw( 'DATE(granted_at) as date, COUNT(*) as count' )
+            ->where( 'status', 'granted' )
+            ->where( 'granted_at', '>=', now()->subDays( 30 ) )
+            ->groupBy( 'date' )
+            ->orderBy( 'date' )
+            ->get();
+
+        return response()->json( [
+            'success' => true,
+            'data'    => [
+                'policies' => $policies->map( fn ( $p ) => [
+                    'id'              => $p->id,
+                    'name'            => $p->name,
+                    'slug'            => $p->slug,
+                    'version'         => $p->version,
+                    'is_required'     => $p->is_required,
+                    'granted_count'   => $p->granted_count,
+                    'withdrawn_count' => $p->withdrawn_count,
+                ] ),
+                'consent_trend' => $consentTrend->map( fn ( $t ) => [
+                    'date'  => $t->date,
+                    'count' => $t->count,
+                ] ),
+            ],
+        ] );
+    }
+
+    /**
+     * Get DPIA overview.
+     */
+    public function dpiaOverview( Request $request ): JsonResponse
+    {
+        $assessments = DataProtectionAssessment::with( 'processingActivity' )
+            ->orderBy( 'created_at', 'desc' )
+            ->paginate( $request->input( 'per_page', 20 ) );
+
+        return response()->json( [
+            'success' => true,
+            'data'    => [
+                'assessments' => $assessments->through( fn ( $a ) => [
+                    'id'                  => $a->id,
+                    'title'               => $a->title,
+                    'processing_activity' => $a->processingActivity?->name,
+                    'status'              => $a->status,
+                    'risk_level'          => $a->overall_risk_level,
+                    'overall_risk_score'  => $a->overall_risk_score,
+                    'assessor_name'       => $a->assessor_name,
+                    'dpo_review_required' => $a->dpo_review_required,
+                    'created_at'          => $a->created_at->toIso8601String(),
+                ] ),
+                'pagination' => [
+                    'current_page' => $assessments->currentPage(),
+                    'last_page'    => $assessments->lastPage(),
+                    'per_page'     => $assessments->perPage(),
+                    'total'        => $assessments->total(),
+                ],
+            ],
+        ] );
+    }
+
+    /**
+     * List compliance reports.
+     */
+    public function reports( Request $request ): JsonResponse
+    {
+        $reports = ScheduledComplianceReport::orderBy( 'created_at', 'desc' )
+            ->paginate( $request->input( 'per_page', 20 ) );
+
+        return response()->json( [
+            'success' => true,
+            'data'    => [
+                'reports' => $reports->through( fn ( $r ) => [
+                    'id'                => $r->id,
+                    'name'              => $r->name,
+                    'type'              => $r->type,
+                    'frequency'         => $r->frequency,
+                    'is_active'         => $r->is_active,
+                    'last_generated_at' => $r->last_generated_at?->toIso8601String(),
+                    'next_scheduled_at' => $r->next_scheduled_at?->toIso8601String(),
+                    'created_at'        => $r->created_at->toIso8601String(),
+                ] ),
+                'pagination' => [
+                    'current_page' => $reports->currentPage(),
+                    'last_page'    => $reports->lastPage(),
+                    'per_page'     => $reports->perPage(),
+                    'total'        => $reports->total(),
+                ],
+            ],
+        ] );
+    }
+
+    /**
+     * Generate a compliance report.
+     */
+    public function generateReport( Request $request ): JsonResponse
+    {
+        $validated = $request->validate( [
+            'type'   => 'required|in:compliance_status,consent_audit,dsr_summary,dpia_summary',
+            'period' => 'required|in:daily,weekly,monthly,quarterly,annual',
+            'format' => 'required|in:pdf,xlsx,json',
+        ] );
+
+        try {
+            $report = $this->reportGenerator->generate(
+                $validated['type'],
+                $validated['period'],
+                $validated['format'],
+            );
+
+            return response()->json( [
+                'success' => true,
+                'message' => 'Report generated successfully.',
+                'data'    => [
+                    'report' => [
+                        'title'        => $report->title,
+                        'type'         => $report->type,
+                        'format'       => $report->format,
+                        'file_path'    => $report->filePath,
+                        'generated_at' => $report->generatedAt->toIso8601String(),
+                    ],
+                ],
+            ] );
+        } catch ( Exception $e ) {
+            // Generate a correlation ID for support reference
+            $errorId = Str::uuid()->toString();
+
+            // Log the full exception with context
+            Log::error( 'Failed to generate compliance report', [
+                'error_id' => $errorId,
+                'type'     => $validated['type'],
+                'period'   => $validated['period'],
+                'format'   => $validated['format'],
+                'user_id'  => $request->user()?->id,
+                'error'    => $e->getMessage(),
+                'trace'    => $e->getTraceAsString(),
+            ] );
+
+            return response()->json( [
+                'success'  => false,
+                'message'  => 'Failed to generate report. Please try again or contact support.',
+                'error_id' => $errorId,
+            ], 500 );
+        }
+    }
+
+    /**
+     * Download a generated report.
+     */
+    public function downloadReport( Request $request, ScheduledComplianceReport $report )
+    {
+        if ( ! $report->last_file_path ) {
+            return response()->json( [
+                'success' => false,
+                'message' => 'No report file available.',
+            ], 404 );
+        }
+
+        $disk = config( 'artisanpack.compliance.compliance.reporting.storage_disk', 'local' );
+
+        if ( ! Storage::disk( $disk )->exists( $report->last_file_path ) ) {
+            return response()->json( [
+                'success' => false,
+                'message' => 'Report file not found.',
+            ], 404 );
+        }
+
+        return Storage::disk( $disk )->download( $report->last_file_path );
+    }
+
+    /**
+     * Calculate the overall consent rate.
+     */
+    protected function calculateConsentRate(): float
+    {
+        $totalPolicies = ConsentPolicy::active()->count();
+        if ( 0 === $totalPolicies ) {
+            return 0.0;
+        }
+
+        // This is a simplified calculation
+        // In practice, you'd want to calculate based on unique users
+        $grantedConsents = ConsentRecord::where( 'status', 'granted' )->count();
+        $totalRecords    = ConsentRecord::count();
+
+        if ( 0 === $totalRecords ) {
+            return 0.0;
+        }
+
+        return round( ( $grantedConsents / $totalRecords) * 100, 2);
+    }
+}

--- a/src/Http/Controllers/Compliance/ComplianceDashboardController.php
+++ b/src/Http/Controllers/Compliance/ComplianceDashboardController.php
@@ -458,7 +458,7 @@ class ComplianceDashboardController extends Controller
             ], 404 );
         }
 
-        $disk = config( 'artisanpack.compliance.compliance.reporting.storage_disk', 'local' );
+        $disk = config( 'artisanpack.compliance.reporting.storage_disk', 'local' );
 
         if ( ! Storage::disk( $disk )->exists( $report->last_file_path ) ) {
             return response()->json( [

--- a/src/Http/Controllers/Compliance/ConsentController.php
+++ b/src/Http/Controllers/Compliance/ConsentController.php
@@ -65,7 +65,7 @@ class ConsentController extends Controller
                 'description' => $policy->description,
                 'version'     => $policy->version,
                 'is_required' => $policy->is_required,
-                'purposes'    => $policy->purposes,
+                'purpose'     => $policy->purpose,
             ] );
 
         return response()->json( [
@@ -85,17 +85,17 @@ class ConsentController extends Controller
             'success' => true,
             'data'    => [
                 'policy' => [
-                    'id'               => $policy->id,
-                    'name'             => $policy->name,
-                    'slug'             => $policy->slug,
-                    'description'      => $policy->description,
-                    'content'          => $policy->content,
-                    'version'          => $policy->version,
-                    'is_required'      => $policy->is_required,
-                    'purposes'         => $policy->purposes,
-                    'data_categories'  => $policy->data_categories,
-                    'retention_period' => $policy->retention_period,
-                    'third_parties'    => $policy->third_parties,
+                    'id'                  => $policy->id,
+                    'name'                => $policy->name,
+                    'slug'                => $policy->slug,
+                    'description'         => $policy->description,
+                    'legal_text'          => $policy->legal_text,
+                    'version'             => $policy->version,
+                    'is_required'         => $policy->is_required,
+                    'purpose'             => $policy->purpose,
+                    'data_categories'     => $policy->data_categories,
+                    'retention_period'    => $policy->retention_period,
+                    'third_party_sharing' => $policy->third_party_sharing,
                 ],
             ],
         ] );

--- a/src/Http/Controllers/Compliance/ConsentController.php
+++ b/src/Http/Controllers/Compliance/ConsentController.php
@@ -242,7 +242,7 @@ class ConsentController extends Controller
     public function cookiePreferences( Request $request ): JsonResponse
     {
         $categories         = $this->cookieHandler->getCategories();
-        $currentPreferences = $this->cookieHandler->getCurrentPreferences( $request );
+        $currentPreferences = $this->cookieHandler->getConsentStatus( $request );
 
         return response()->json( [
             'success' => true,
@@ -263,11 +263,15 @@ class ConsentController extends Controller
             'preferences.*' => 'boolean',
         ] );
 
-        $this->cookieHandler->savePreferences( $request, $validated['preferences'] );
+        // setConsent() returns a Symfony Cookie that has to be queued
+        // on the response — withCookie() does that. Without it, the
+        // browser never receives the updated consent state and the
+        // "saved" message would be a lie.
+        $cookie = $this->cookieHandler->setConsent( $validated['preferences'] );
 
         return response()->json( [
             'success' => true,
             'message' => 'Cookie preferences saved successfully.',
-        ]);
+        ] )->withCookie( $cookie );
     }
 }

--- a/src/Http/Controllers/Compliance/ConsentController.php
+++ b/src/Http/Controllers/Compliance/ConsentController.php
@@ -183,7 +183,7 @@ class ConsentController extends Controller
             'data'    => [
                 'history' => $history->through( fn ( $record ) => [
                     'id'           => $record->id,
-                    'policy_name'  => $record->policy->name,
+                    'policy_name'  => $record->policy?->name,
                     'status'       => $record->status,
                     'granted_at'   => $record->granted_at?->toIso8601String(),
                     'withdrawn_at' => $record->withdrawn_at?->toIso8601String(),

--- a/src/Http/Controllers/Compliance/ConsentController.php
+++ b/src/Http/Controllers/Compliance/ConsentController.php
@@ -1,0 +1,273 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Http\Controllers\Compliance;
+
+use ArtisanPackUI\Compliance\Compliance\Consent\ConsentManager;
+use ArtisanPackUI\Compliance\Compliance\Consent\ConsentPolicyService;
+use ArtisanPackUI\Compliance\Compliance\Consent\CookieConsentHandler;
+use ArtisanPackUI\Compliance\Models\ConsentPolicy;
+use ArtisanPackUI\Compliance\Models\ConsentRecord;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+class ConsentController extends Controller
+{
+    public function __construct(
+        protected ConsentManager $consentManager,
+        protected ConsentPolicyService $policyService,
+        protected CookieConsentHandler $cookieHandler,
+    ) {
+    }
+
+    /**
+     * Display the user's consent overview.
+     */
+    public function index( Request $request ): JsonResponse
+    {
+        $user = $request->user();
+
+        $consents = ConsentRecord::where( 'user_id', $user->id )
+            ->with( 'policy' )
+            ->whereHas( 'policy' ) // Only include records with existing policies
+            ->get()
+            ->map( fn ( $record ) => [
+                'id'           => $record->id,
+                'policy_name'  => $record->policy?->name,
+                'policy_slug'  => $record->policy?->slug,
+                'status'       => $record->status,
+                'granted_at'   => $record->granted_at?->toIso8601String(),
+                'withdrawn_at' => $record->withdrawn_at?->toIso8601String(),
+                'expires_at'   => $record->expires_at?->toIso8601String(),
+            ] );
+
+        return response()->json( [
+            'success' => true,
+            'data'    => [
+                'consents' => $consents,
+            ],
+        ] );
+    }
+
+    /**
+     * List all available consent policies.
+     */
+    public function policies( Request $request ): JsonResponse
+    {
+        $policies = ConsentPolicy::active()
+            ->get()
+            ->map( fn ( $policy ) => [
+                'id'          => $policy->id,
+                'name'        => $policy->name,
+                'slug'        => $policy->slug,
+                'description' => $policy->description,
+                'version'     => $policy->version,
+                'is_required' => $policy->is_required,
+                'purposes'    => $policy->purposes,
+            ] );
+
+        return response()->json( [
+            'success' => true,
+            'data'    => [
+                'policies' => $policies,
+            ],
+        ] );
+    }
+
+    /**
+     * Show a specific consent policy.
+     */
+    public function showPolicy( ConsentPolicy $policy ): JsonResponse
+    {
+        return response()->json( [
+            'success' => true,
+            'data'    => [
+                'policy' => [
+                    'id'               => $policy->id,
+                    'name'             => $policy->name,
+                    'slug'             => $policy->slug,
+                    'description'      => $policy->description,
+                    'content'          => $policy->content,
+                    'version'          => $policy->version,
+                    'is_required'      => $policy->is_required,
+                    'purposes'         => $policy->purposes,
+                    'data_categories'  => $policy->data_categories,
+                    'retention_period' => $policy->retention_period,
+                    'third_parties'    => $policy->third_parties,
+                ],
+            ],
+        ] );
+    }
+
+    /**
+     * Grant consent to a policy.
+     */
+    public function grant( Request $request ): JsonResponse
+    {
+        $validated = $request->validate( [
+            'policy_id' => 'required|exists:consent_policies,id',
+            'purposes'  => 'nullable|array',
+            'metadata'  => 'nullable|array',
+        ] );
+
+        $user   = $request->user();
+        $policy = ConsentPolicy::findOrFail( $validated['policy_id'] );
+
+        $record = $this->consentManager->grantConsent(
+            $user,
+            $policy,
+            $validated['purposes'] ?? null,
+            $validated['metadata'] ?? [],
+        );
+
+        return response()->json( [
+            'success' => true,
+            'message' => 'Consent granted successfully.',
+            'data'    => [
+                'consent_record' => [
+                    'id'         => $record->id,
+                    'policy_id'  => $record->consent_policy_id,
+                    'status'     => $record->status,
+                    'granted_at' => $record->granted_at->toIso8601String(),
+                ],
+            ],
+        ] );
+    }
+
+    /**
+     * Withdraw consent from a policy.
+     */
+    public function withdraw( Request $request ): JsonResponse
+    {
+        $validated = $request->validate( [
+            'policy_id' => 'required|exists:consent_policies,id',
+            'reason'    => 'nullable|string|max:500',
+        ] );
+
+        $user   = $request->user();
+        $policy = ConsentPolicy::findOrFail( $validated['policy_id'] );
+
+        $record = $this->consentManager->withdrawConsent(
+            $user,
+            $policy,
+            $validated['reason'] ?? null,
+        );
+
+        if ( ! $record ) {
+            return response()->json( [
+                'success' => false,
+                'message' => 'No active consent found to withdraw.',
+            ], 404 );
+        }
+
+        return response()->json( [
+            'success' => true,
+            'message' => 'Consent withdrawn successfully.',
+            'data'    => [
+                'consent_record' => [
+                    'id'           => $record->id,
+                    'policy_id'    => $record->consent_policy_id,
+                    'status'       => $record->status,
+                    'withdrawn_at' => $record->withdrawn_at->toIso8601String(),
+                ],
+            ],
+        ] );
+    }
+
+    /**
+     * Get consent history for the current user.
+     */
+    public function history( Request $request ): JsonResponse
+    {
+        $user = $request->user();
+
+        // Sanitize and bound the per_page parameter to prevent abuse
+        $perPage = max( 1, min( (int) $request->input( 'per_page', 15 ), 100 ) );
+
+        $history = ConsentRecord::where( 'user_id', $user->id )
+            ->with( ['policy', 'auditLogs'] )
+            ->orderBy( 'created_at', 'desc' )
+            ->paginate( $perPage );
+
+        return response()->json( [
+            'success' => true,
+            'data'    => [
+                'history' => $history->through( fn ( $record ) => [
+                    'id'           => $record->id,
+                    'policy_name'  => $record->policy->name,
+                    'status'       => $record->status,
+                    'granted_at'   => $record->granted_at?->toIso8601String(),
+                    'withdrawn_at' => $record->withdrawn_at?->toIso8601String(),
+                    'audit_logs'   => $record->auditLogs->map( fn ( $log ) => [
+                        'action'     => $log->action,
+                        'created_at' => $log->created_at->toIso8601String(),
+                    ] ),
+                ] ),
+                'pagination' => [
+                    'current_page' => $history->currentPage(),
+                    'last_page'    => $history->lastPage(),
+                    'per_page'     => $history->perPage(),
+                    'total'        => $history->total(),
+                ],
+            ],
+        ] );
+    }
+
+    /**
+     * Verify if the user has given consent to a policy.
+     */
+    public function verify( Request $request, ConsentPolicy $policy ): JsonResponse
+    {
+        $user = $request->user();
+
+        $verification = $this->consentManager->verifyConsent( $user, $policy );
+
+        return response()->json( [
+            'success' => true,
+            'data'    => [
+                'has_consent'    => $verification->hasConsent,
+                'is_valid'       => $verification->isValid,
+                'expires_at'     => $verification->expiresAt?->toIso8601String(),
+                'needs_renewal'  => $verification->needsRenewal,
+                'policy_version' => $verification->policyVersion,
+            ],
+        ] );
+    }
+
+    /**
+     * Get cookie consent preferences form.
+     */
+    public function cookiePreferences( Request $request ): JsonResponse
+    {
+        $categories         = $this->cookieHandler->getCategories();
+        $currentPreferences = $this->cookieHandler->getCurrentPreferences( $request );
+
+        return response()->json( [
+            'success' => true,
+            'data'    => [
+                'categories'          => $categories,
+                'current_preferences' => $currentPreferences,
+            ],
+        ] );
+    }
+
+    /**
+     * Save cookie consent preferences.
+     */
+    public function saveCookiePreferences( Request $request ): JsonResponse
+    {
+        $validated = $request->validate( [
+            'preferences'   => 'required|array',
+            'preferences.*' => 'boolean',
+        ] );
+
+        $this->cookieHandler->savePreferences( $request, $validated['preferences'] );
+
+        return response()->json( [
+            'success' => true,
+            'message' => 'Cookie preferences saved successfully.',
+        ]);
+    }
+}

--- a/src/Http/Controllers/Compliance/ConsentController.php
+++ b/src/Http/Controllers/Compliance/ConsentController.php
@@ -12,6 +12,7 @@ use ArtisanPackUI\Compliance\Models\ConsentRecord;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use InvalidArgumentException;
 
 class ConsentController extends Controller
 {
@@ -111,13 +112,23 @@ class ConsentController extends Controller
             'metadata' => 'nullable|array',
         ] );
 
-        $record = $this->consentManager->grant(
-            $request->user()->id,
-            $validated['purpose'],
-            [
-                'metadata' => $validated['metadata'] ?? null,
-            ],
-        );
+        try {
+            $record = $this->consentManager->grant(
+                $request->user()->id,
+                $validated['purpose'],
+                [
+                    'metadata' => $validated['metadata'] ?? null,
+                ],
+            );
+        } catch ( InvalidArgumentException $e ) {
+            // Unknown / inactive purpose is client input, not a server
+            // fault — surface as a 422 so callers get a usable error
+            // payload instead of an opaque 500.
+            return response()->json( [
+                'success' => false,
+                'message' => $e->getMessage(),
+            ], 422 );
+        }
 
         return response()->json( [
             'success' => true,

--- a/src/Http/Controllers/Compliance/ConsentController.php
+++ b/src/Http/Controllers/Compliance/ConsentController.php
@@ -107,19 +107,16 @@ class ConsentController extends Controller
     public function grant( Request $request ): JsonResponse
     {
         $validated = $request->validate( [
-            'policy_id' => 'required|exists:consent_policies,id',
-            'purposes'  => 'nullable|array',
-            'metadata'  => 'nullable|array',
+            'purpose'  => 'required|string',
+            'metadata' => 'nullable|array',
         ] );
 
-        $user   = $request->user();
-        $policy = ConsentPolicy::findOrFail( $validated['policy_id'] );
-
-        $record = $this->consentManager->grantConsent(
-            $user,
-            $policy,
-            $validated['purposes'] ?? null,
-            $validated['metadata'] ?? [],
+        $record = $this->consentManager->grant(
+            $request->user()->id,
+            $validated['purpose'],
+            [
+                'metadata' => $validated['metadata'] ?? null,
+            ],
         );
 
         return response()->json( [
@@ -128,9 +125,10 @@ class ConsentController extends Controller
             'data'    => [
                 'consent_record' => [
                     'id'         => $record->id,
-                    'policy_id'  => $record->consent_policy_id,
+                    'purpose'    => $record->purpose,
+                    'policy_id'  => $record->policy_id,
                     'status'     => $record->status,
-                    'granted_at' => $record->granted_at->toIso8601String(),
+                    'granted_at' => $record->granted_at?->toIso8601String(),
                 ],
             ],
         ] );
@@ -142,20 +140,17 @@ class ConsentController extends Controller
     public function withdraw( Request $request ): JsonResponse
     {
         $validated = $request->validate( [
-            'policy_id' => 'required|exists:consent_policies,id',
-            'reason'    => 'nullable|string|max:500',
+            'purpose' => 'required|string',
+            'reason'  => 'nullable|string|max:500',
         ] );
 
-        $user   = $request->user();
-        $policy = ConsentPolicy::findOrFail( $validated['policy_id'] );
-
-        $record = $this->consentManager->withdrawConsent(
-            $user,
-            $policy,
+        $withdrawn = $this->consentManager->withdraw(
+            $request->user()->id,
+            $validated['purpose'],
             $validated['reason'] ?? null,
         );
 
-        if ( ! $record ) {
+        if ( ! $withdrawn ) {
             return response()->json( [
                 'success' => false,
                 'message' => 'No active consent found to withdraw.',
@@ -165,14 +160,6 @@ class ConsentController extends Controller
         return response()->json( [
             'success' => true,
             'message' => 'Consent withdrawn successfully.',
-            'data'    => [
-                'consent_record' => [
-                    'id'           => $record->id,
-                    'policy_id'    => $record->consent_policy_id,
-                    'status'       => $record->status,
-                    'withdrawn_at' => $record->withdrawn_at->toIso8601String(),
-                ],
-            ],
         ] );
     }
 
@@ -218,11 +205,16 @@ class ConsentController extends Controller
     /**
      * Verify if the user has given consent to a policy.
      */
-    public function verify( Request $request, ConsentPolicy $policy ): JsonResponse
+    public function verify( Request $request ): JsonResponse
     {
-        $user = $request->user();
+        $validated = $request->validate( [
+            'purpose' => 'required|string',
+        ] );
 
-        $verification = $this->consentManager->verifyConsent( $user, $policy );
+        $verification = $this->consentManager->verifyConsent(
+            $request->user()->id,
+            $validated['purpose'],
+        );
 
         return response()->json( [
             'success' => true,

--- a/src/Http/Controllers/Compliance/ErasureController.php
+++ b/src/Http/Controllers/Compliance/ErasureController.php
@@ -105,7 +105,7 @@ class ErasureController extends Controller
         }
 
         // Calculate scheduled date based on grace period
-        $gracePeriodDays = config( 'artisanpack.compliance.compliance.erasure.grace_period_days', 30 );
+        $gracePeriodDays = config( 'artisanpack.compliance.erasure.grace_period_days', 30 );
         $scheduledAt     = now()->addDays( $gracePeriodDays );
 
         // Create erasure request

--- a/src/Http/Controllers/Compliance/ErasureController.php
+++ b/src/Http/Controllers/Compliance/ErasureController.php
@@ -1,0 +1,272 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Http\Controllers\Compliance;
+
+use ArtisanPackUI\Compliance\Compliance\Erasure\ErasureService;
+use ArtisanPackUI\Compliance\Events\ErasureRequested;
+use ArtisanPackUI\Compliance\Models\ErasureRequest;
+use Cache;
+use Hash;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Str;
+
+class ErasureController extends Controller
+{
+    public function __construct(
+        protected ErasureService $erasureService,
+    ) {
+    }
+
+    /**
+     * Display the user's erasure requests.
+     */
+    public function index( Request $request ): JsonResponse
+    {
+        $user = $request->user();
+
+        $perPage = min( (int) $request->input( 'per_page', 15 ), 100 );
+
+        $requests = ErasureRequest::where( 'user_id', $user->id )
+            ->orderBy( 'created_at', 'desc' )
+            ->paginate( $perPage );
+
+        return response()->json( [
+            'success' => true,
+            'data'    => [
+                'requests' => $requests->through( fn ( $req ) => [
+                    'id'             => $req->id,
+                    'request_number' => $req->request_number,
+                    'status'         => $req->status,
+                    'scope'          => $req->scope,
+                    'scheduled_at'   => $req->scheduled_at?->toIso8601String(),
+                    'completed_at'   => $req->completed_at?->toIso8601String(),
+                    'created_at'     => $req->created_at->toIso8601String(),
+                ] ),
+                'pagination' => [
+                    'current_page' => $requests->currentPage(),
+                    'last_page'    => $requests->lastPage(),
+                    'per_page'     => $requests->perPage(),
+                    'total'        => $requests->total(),
+                ],
+            ],
+        ] );
+    }
+
+    /**
+     * Create a new erasure request.
+     */
+    public function request( Request $request ): JsonResponse
+    {
+        $validated = $request->validate( [
+            'scope'               => 'required|in:full,partial',
+            'data_categories'     => 'required_if:scope,partial|array',
+            'data_categories.*'   => 'string|max:100',
+            'reason'              => 'nullable|string|max:1000',
+            'verification_method' => 'required|in:password,email,two_factor',
+            'verification_value'  => 'required|string',
+        ] );
+
+        $user = $request->user();
+
+        // Verify user identity based on verification method
+        $verified = $this->verifyIdentity(
+            $user,
+            $validated['verification_method'],
+            $validated['verification_value'],
+        );
+
+        if ( ! $verified ) {
+            return response()->json( [
+                'success' => false,
+                'message' => 'Identity verification failed.',
+            ], 403 );
+        }
+
+        // Check for pending requests
+        $pendingRequest = ErasureRequest::where( 'user_id', $user->id )
+            ->whereIn( 'status', ['pending', 'processing', 'scheduled'] )
+            ->first();
+
+        if ( $pendingRequest ) {
+            return response()->json( [
+                'success' => false,
+                'message' => 'You already have a pending erasure request.',
+                'data'    => [
+                    'existing_request' => [
+                        'request_number' => $pendingRequest->request_number,
+                        'status'         => $pendingRequest->status,
+                    ],
+                ],
+            ], 409 );
+        }
+
+        // Calculate scheduled date based on grace period
+        $gracePeriodDays = config( 'artisanpack.compliance.compliance.erasure.grace_period_days', 30 );
+        $scheduledAt     = now()->addDays( $gracePeriodDays );
+
+        // Create erasure request
+        $erasureRequest = ErasureRequest::create( [
+            'request_number'  => 'ERA-' . strtoupper( Str::random( 10 ) ),
+            'user_id'         => $user->id,
+            'status'          => 'pending',
+            'scope'           => $validated['scope'],
+            'data_categories' => $validated['data_categories'] ?? null,
+            'reason'          => $validated['reason'] ?? null,
+            'scheduled_at'    => $scheduledAt,
+            'ip_address'      => $request->ip(),
+            'user_agent'      => $request->userAgent(),
+        ] );
+
+        // Fire event
+        event( new ErasureRequested( $erasureRequest ) );
+
+        return response()->json( [
+            'success' => true,
+            'message' => 'Erasure request submitted successfully.',
+            'data'    => [
+                'request' => [
+                    'request_number'    => $erasureRequest->request_number,
+                    'status'            => $erasureRequest->status,
+                    'scope'             => $erasureRequest->scope,
+                    'scheduled_at'      => $erasureRequest->scheduled_at->toIso8601String(),
+                    'grace_period_days' => $gracePeriodDays,
+                ],
+            ],
+        ], 201 );
+    }
+
+    /**
+     * Get the status of a specific erasure request.
+     */
+    public function status( Request $request, ErasureRequest $erasureRequest ): JsonResponse
+    {
+        $user = $request->user();
+
+        // Ensure user can only access their own requests
+        if ( $erasureRequest->user_id !== $user->id ) {
+            return response()->json( [
+                'success' => false,
+                'message' => 'Erasure request not found.',
+            ], 404 );
+        }
+
+        $logs = $erasureRequest->logs()
+            ->orderBy( 'created_at', 'desc' )
+            ->limit( 10 )
+            ->get();
+
+        return response()->json( [
+            'success' => true,
+            'data'    => [
+                'request' => [
+                    'request_number'  => $erasureRequest->request_number,
+                    'status'          => $erasureRequest->status,
+                    'scope'           => $erasureRequest->scope,
+                    'data_categories' => $erasureRequest->data_categories,
+                    'scheduled_at'    => $erasureRequest->scheduled_at?->toIso8601String(),
+                    'started_at'      => $erasureRequest->started_at?->toIso8601String(),
+                    'completed_at'    => $erasureRequest->completed_at?->toIso8601String(),
+                    'error_message'   => $erasureRequest->error_message,
+                    'created_at'      => $erasureRequest->created_at->toIso8601String(),
+                ],
+                'logs' => $logs->map( fn ( $log ) => [
+                    'handler'          => $log->handler_class,
+                    'status'           => $log->status,
+                    'records_affected' => $log->records_affected,
+                    'created_at'       => $log->created_at->toIso8601String(),
+                ] ),
+                'can_cancel' => in_array( $erasureRequest->status, ['pending', 'scheduled'] ),
+            ],
+        ] );
+    }
+
+    /**
+     * Cancel a pending erasure request.
+     */
+    public function cancel( Request $request, ErasureRequest $erasureRequest ): JsonResponse
+    {
+        $user = $request->user();
+
+        // Ensure user can only cancel their own requests
+        if ( $erasureRequest->user_id !== $user->id ) {
+            return response()->json( [
+                'success' => false,
+                'message' => 'Erasure request not found.',
+            ], 404 );
+        }
+
+        // Check if request can be cancelled
+        if ( ! in_array( $erasureRequest->status, ['pending', 'scheduled'] ) ) {
+            return response()->json( [
+                'success' => false,
+                'message' => 'This erasure request cannot be cancelled.',
+            ], 422 );
+        }
+
+        $validated = $request->validate( [
+            'reason' => 'nullable|string|max:1000',
+        ] );
+
+        $erasureRequest->update( [
+            'status'              => 'cancelled',
+            'cancelled_at'        => now(),
+            'cancellation_reason' => $validated['reason'] ?? null,
+        ] );
+
+        return response()->json( [
+            'success' => true,
+            'message' => 'Erasure request cancelled successfully.',
+            'data'    => [
+                'request' => [
+                    'request_number' => $erasureRequest->request_number,
+                    'status'         => $erasureRequest->status,
+                ],
+            ],
+        ] );
+    }
+
+    /**
+     * Verify user identity for erasure request.
+     */
+    protected function verifyIdentity( $user, string $method, string $value ): bool
+    {
+        return match ( $method ) {
+            'password'   => Hash::check( $value, $user->password ),
+            'email'      => $this->verifyEmailCode( $user, $value ),
+            'two_factor' => $this->verifyTwoFactorCode( $user, $value ),
+            default      => false,
+        };
+    }
+
+    /**
+     * Verify email verification code.
+     */
+    protected function verifyEmailCode( $user, string $code ): bool
+    {
+        $cacheKey   = 'erasure_verification_' . $user->id;
+        $storedCode = Cache::get( $cacheKey );
+
+        if ( $storedCode && hash_equals( $storedCode, $code ) ) {
+            Cache::forget( $cacheKey );
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Verify two-factor authentication code.
+     */
+    protected function verifyTwoFactorCode( $user, string $code ): bool
+    {
+        if ( ! method_exists( $user, 'verifyTwoFactorCode' ) ) {
+            return false;
+        }
+
+        return $user->verifyTwoFactorCode( $code);
+    }
+}

--- a/src/Http/Controllers/Compliance/PortabilityController.php
+++ b/src/Http/Controllers/Compliance/PortabilityController.php
@@ -97,7 +97,7 @@ class PortabilityController extends Controller
             ->where( 'created_at', '>=', now()->subDays( 30 ) )
             ->count();
 
-        $maxExportsPerMonth = config( 'artisanpack.compliance.compliance.portability.max_exports_per_month', 5 );
+        $maxExportsPerMonth = config( 'artisanpack.compliance.portability.max_exports_per_month', 5 );
 
         if ( $recentExports >= $maxExportsPerMonth ) {
             return response()->json( [
@@ -114,7 +114,7 @@ class PortabilityController extends Controller
             'format'           => $validated['format'],
             'data_categories'  => $validated['data_categories'] ?? null,
             'include_metadata' => $validated['include_metadata'] ?? true,
-            'download_limit'   => config( 'artisanpack.compliance.compliance.portability.download_limit', 3 ),
+            'download_limit'   => config( 'artisanpack.compliance.portability.download_limit', 3 ),
             'download_count'   => 0,
             'ip_address'       => $request->ip(),
             'user_agent'       => $request->userAgent(),
@@ -219,7 +219,7 @@ class PortabilityController extends Controller
 
         // Check if file exists
         $filePath = $portabilityRequest->file_path;
-        $disk     = config( 'artisanpack.compliance.compliance.portability.storage_disk', 'local' );
+        $disk     = config( 'artisanpack.compliance.portability.storage_disk', 'local' );
 
         if ( ! Storage::disk( $disk )->exists( $filePath ) ) {
             return response()->json( [

--- a/src/Http/Controllers/Compliance/PortabilityController.php
+++ b/src/Http/Controllers/Compliance/PortabilityController.php
@@ -1,0 +1,286 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Http\Controllers\Compliance;
+
+use ArtisanPackUI\Compliance\Compliance\Portability\PortabilityService;
+use ArtisanPackUI\Compliance\Events\DataExportRequested;
+use ArtisanPackUI\Compliance\Jobs\ProcessPortabilityRequestJob;
+use ArtisanPackUI\Compliance\Models\PortabilityRequest;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class PortabilityController extends Controller
+{
+    public function __construct(
+        protected PortabilityService $portabilityService,
+    ) {
+    }
+
+    /**
+     * Display the user's portability requests.
+     */
+    public function index( Request $request ): JsonResponse
+    {
+        $user = $request->user();
+
+        $requests = PortabilityRequest::where( 'user_id', $user->id )
+            ->orderBy( 'created_at', 'desc' )
+            ->paginate( $request->input( 'per_page', 15 ) );
+
+        return response()->json( [
+            'success' => true,
+            'data'    => [
+                'requests' => $requests->through( fn ( $req ) => [
+                    'id'             => $req->id,
+                    'request_number' => $req->request_number,
+                    'status'         => $req->status,
+                    'format'         => $req->format,
+                    'download_count' => $req->download_count,
+                    'download_limit' => $req->download_limit,
+                    'expires_at'     => $req->expires_at?->toIso8601String(),
+                    'completed_at'   => $req->completed_at?->toIso8601String(),
+                    'created_at'     => $req->created_at->toIso8601String(),
+                    'can_download'   => 'completed' === $req->status
+                        && $req->download_count < $req->download_limit
+                        && ( ! $req->expires_at || $req->expires_at->isFuture() ),
+                ] ),
+                'pagination' => [
+                    'current_page' => $requests->currentPage(),
+                    'last_page'    => $requests->lastPage(),
+                    'per_page'     => $requests->perPage(),
+                    'total'        => $requests->total(),
+                ],
+            ],
+        ] );
+    }
+
+    /**
+     * Create a new portability request.
+     */
+    public function request( Request $request ): JsonResponse
+    {
+        $validated = $request->validate( [
+            'format'            => 'required|in:json,xml,csv',
+            'data_categories'   => 'nullable|array',
+            'data_categories.*' => 'string|max:100',
+            'include_metadata'  => 'nullable|boolean',
+        ] );
+
+        $user = $request->user();
+
+        // Check for pending requests
+        $pendingRequest = PortabilityRequest::where( 'user_id', $user->id )
+            ->whereIn( 'status', ['pending', 'processing'] )
+            ->first();
+
+        if ( $pendingRequest ) {
+            return response()->json( [
+                'success' => false,
+                'message' => 'You already have a pending data export request.',
+                'data'    => [
+                    'existing_request' => [
+                        'request_number' => $pendingRequest->request_number,
+                        'status'         => $pendingRequest->status,
+                    ],
+                ],
+            ], 409 );
+        }
+
+        // Check rate limit for exports
+        $recentExports = PortabilityRequest::where( 'user_id', $user->id )
+            ->where( 'created_at', '>=', now()->subDays( 30 ) )
+            ->count();
+
+        $maxExportsPerMonth = config( 'artisanpack.compliance.compliance.portability.max_exports_per_month', 5 );
+
+        if ( $recentExports >= $maxExportsPerMonth ) {
+            return response()->json( [
+                'success' => false,
+                'message' => "You have reached the maximum of {$maxExportsPerMonth} export requests per month.",
+            ], 429 );
+        }
+
+        // Create portability request
+        $portabilityRequest = PortabilityRequest::create( [
+            'request_number'   => 'PRT-' . strtoupper( Str::random( 10 ) ),
+            'user_id'          => $user->id,
+            'status'           => 'pending',
+            'format'           => $validated['format'],
+            'data_categories'  => $validated['data_categories'] ?? null,
+            'include_metadata' => $validated['include_metadata'] ?? true,
+            'download_limit'   => config( 'artisanpack.compliance.compliance.portability.download_limit', 3 ),
+            'download_count'   => 0,
+            'ip_address'       => $request->ip(),
+            'user_agent'       => $request->userAgent(),
+        ] );
+
+        // Fire event
+        event( new DataExportRequested( $portabilityRequest ) );
+
+        // Dispatch processing job
+        ProcessPortabilityRequestJob::dispatch( $portabilityRequest );
+
+        return response()->json( [
+            'success' => true,
+            'message' => 'Data export request submitted successfully. You will be notified when it\'s ready.',
+            'data'    => [
+                'request' => [
+                    'request_number' => $portabilityRequest->request_number,
+                    'status'         => $portabilityRequest->status,
+                    'format'         => $portabilityRequest->format,
+                ],
+            ],
+        ], 201 );
+    }
+
+    /**
+     * Get the status of a specific portability request.
+     */
+    public function status( Request $request, PortabilityRequest $portabilityRequest ): JsonResponse
+    {
+        $user = $request->user();
+
+        // Ensure user can only access their own requests
+        if ( $portabilityRequest->user_id !== $user->id ) {
+            return response()->json( [
+                'success' => false,
+                'message' => 'Export request not found.',
+            ], 404 );
+        }
+
+        return response()->json( [
+            'success' => true,
+            'data'    => [
+                'request' => [
+                    'request_number'      => $portabilityRequest->request_number,
+                    'status'              => $portabilityRequest->status,
+                    'format'              => $portabilityRequest->format,
+                    'data_categories'     => $portabilityRequest->data_categories,
+                    'file_size'           => $portabilityRequest->file_size,
+                    'file_size_formatted' => $this->formatBytes( $portabilityRequest->file_size ),
+                    'download_count'      => $portabilityRequest->download_count,
+                    'download_limit'      => $portabilityRequest->download_limit,
+                    'expires_at'          => $portabilityRequest->expires_at?->toIso8601String(),
+                    'completed_at'        => $portabilityRequest->completed_at?->toIso8601String(),
+                    'error_message'       => $portabilityRequest->error_message,
+                    'created_at'          => $portabilityRequest->created_at->toIso8601String(),
+                ],
+                'can_download' => 'completed' === $portabilityRequest->status
+                    && $portabilityRequest->download_count < $portabilityRequest->download_limit
+                    && ( ! $portabilityRequest->expires_at || $portabilityRequest->expires_at->isFuture() ),
+            ],
+        ] );
+    }
+
+    /**
+     * Download the exported data.
+     */
+    public function download( Request $request, PortabilityRequest $portabilityRequest ): JsonResponse|StreamedResponse
+    {
+        $user = $request->user();
+
+        // Ensure user can only download their own exports
+        if ( $portabilityRequest->user_id !== $user->id ) {
+            return response()->json( [
+                'success' => false,
+                'message' => 'Export request not found.',
+            ], 404 );
+        }
+
+        // Check if export is ready
+        if ( 'completed' !== $portabilityRequest->status ) {
+            return response()->json( [
+                'success' => false,
+                'message' => 'Export is not ready for download.',
+            ], 422 );
+        }
+
+        // Check download limit
+        if ( $portabilityRequest->download_count >= $portabilityRequest->download_limit ) {
+            return response()->json( [
+                'success' => false,
+                'message' => 'Download limit reached.',
+            ], 403 );
+        }
+
+        // Check expiration
+        if ( $portabilityRequest->expires_at && $portabilityRequest->expires_at->isPast() ) {
+            return response()->json( [
+                'success' => false,
+                'message' => 'Download link has expired.',
+            ], 410 );
+        }
+
+        // Check if file exists
+        $filePath = $portabilityRequest->file_path;
+        $disk     = config( 'artisanpack.compliance.compliance.portability.storage_disk', 'local' );
+
+        if ( ! Storage::disk( $disk )->exists( $filePath ) ) {
+            return response()->json( [
+                'success' => false,
+                'message' => 'Export file not found. Please request a new export.',
+            ], 404 );
+        }
+
+        // Increment download count
+        $portabilityRequest->increment( 'download_count' );
+        $portabilityRequest->update( [
+            'last_downloaded_at' => now(),
+        ] );
+
+        // Get file extension based on format
+        $extension = match ( $portabilityRequest->format ) {
+            'json'  => 'json',
+            'xml'   => 'xml',
+            'csv'   => 'zip', // CSV exports are zipped
+            default => 'zip',
+        };
+
+        $filename = "data-export-{$portabilityRequest->request_number}.{$extension}";
+
+        // Stream the file download
+        return Storage::disk( $disk )->download( $filePath, $filename, [
+            'Content-Type' => $this->getContentType( $extension ),
+        ] );
+    }
+
+    /**
+     * Format bytes to human readable size.
+     */
+    protected function formatBytes( ?int $bytes ): ?string
+    {
+        if ( null === $bytes ) {
+            return null;
+        }
+
+        $units = ['B', 'KB', 'MB', 'GB'];
+        $i     = 0;
+
+        while ( $bytes >= 1024 && $i < count( $units ) - 1 ) {
+            $bytes /= 1024;
+            $i++;
+        }
+
+        return round( $bytes, 2 ) . ' ' . $units[ $i ];
+    }
+
+    /**
+     * Get content type for file extension.
+     */
+    protected function getContentType( string $extension ): string
+    {
+        return match ( $extension ) {
+            'json'  => 'application/json',
+            'xml'   => 'application/xml',
+            'csv'   => 'text/csv',
+            'zip'   => 'application/zip',
+            default => 'application/octet-stream',
+        };
+    }
+}

--- a/src/Jobs/ProcessErasureRequestJob.php
+++ b/src/Jobs/ProcessErasureRequestJob.php
@@ -1,0 +1,57 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Jobs;
+
+use ArtisanPackUI\Compliance\Compliance\Erasure\ErasureService;
+use ArtisanPackUI\Compliance\Models\ErasureRequest;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class ProcessErasureRequestJob implements ShouldQueue
+{
+    use Dispatchable;
+use InteractsWithQueue;
+use Queueable;
+use SerializesModels;
+
+    /**
+     * The number of times the job may be attempted.
+     */
+    public int $tries = 3;
+
+    /**
+     * The number of seconds to wait before retrying.
+     */
+    public int $backoff = 60;
+
+    public function __construct( public ErasureRequest $request )
+    {
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle( ErasureService $erasureService ): void
+    {
+        $erasureService->processRequest( $this->request );
+    }
+
+    /**
+     * Get the tags that should be assigned to the job.
+     *
+     * @return array<string>
+     */
+    public function tags(): array
+    {
+        return [
+            'compliance',
+            'erasure',
+            'request:' . $this->request->request_number,
+        ];
+    }
+}

--- a/src/Jobs/ProcessPortabilityRequestJob.php
+++ b/src/Jobs/ProcessPortabilityRequestJob.php
@@ -1,0 +1,57 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Jobs;
+
+use ArtisanPackUI\Compliance\Compliance\Portability\PortabilityService;
+use ArtisanPackUI\Compliance\Models\PortabilityRequest;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class ProcessPortabilityRequestJob implements ShouldQueue
+{
+    use Dispatchable;
+use InteractsWithQueue;
+use Queueable;
+use SerializesModels;
+
+    /**
+     * The number of times the job may be attempted.
+     */
+    public int $tries = 3;
+
+    /**
+     * The number of seconds to wait before retrying.
+     */
+    public int $backoff = 60;
+
+    public function __construct( public PortabilityRequest $request )
+    {
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle( PortabilityService $portabilityService ): void
+    {
+        $portabilityService->processRequest( $this->request );
+    }
+
+    /**
+     * Get the tags that should be assigned to the job.
+     *
+     * @return array<string>
+     */
+    public function tags(): array
+    {
+        return [
+            'compliance',
+            'portability',
+            'request:' . $this->request->request_number,
+        ];
+    }
+}

--- a/src/Jobs/RunComplianceChecksJob.php
+++ b/src/Jobs/RunComplianceChecksJob.php
@@ -1,0 +1,51 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Jobs;
+
+use ArtisanPackUI\Compliance\Compliance\Monitoring\ComplianceMonitor;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class RunComplianceChecksJob implements ShouldQueue
+{
+    use Dispatchable;
+use InteractsWithQueue;
+use Queueable;
+use SerializesModels;
+
+    /**
+     * The number of times the job may be attempted.
+     */
+    public int $tries = 1;
+
+    public function __construct( public ?string $category = null )
+    {
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle( ComplianceMonitor $monitor ): void
+    {
+        if ( $this->category ) {
+            $monitor->runChecksByCategory( $this->category );
+        } else {
+            $monitor->runAllChecks();
+        }
+    }
+
+    /**
+     * Get the tags that should be assigned to the job.
+     *
+     * @return array<string>
+     */
+    public function tags(): array
+    {
+        return ['compliance', 'checks'];
+    }
+}


### PR DESCRIPTION
## Summary

**Wave 6's last extraction.** Ports the GDPR / CCPA / LGPD compliance slice out of `artisanpack-ui/security` 1.x into this package, re-namespaced under `ArtisanPackUI\Compliance\*`. **120 files** total.

After this lands, `compliance` is feature-complete for v0.x and Wave 6 is fully done — the Security 2.0 split is shipped end-to-end across `security-auth`, `security-advanced-auth`, `secure-uploads`, `security-analytics`, and now `compliance`. The eventual security 2.0 slim-down (separately tracked) will retire all these classes from `artisanpack-ui/security`.

## What's ported

**`src/Compliance/**` (48 files)** — Assessment (DPIA service, processing activity service, risk calculator), Consent (manager + policy service + cookie handler + verification), Erasure (service + 2 default handlers), Middleware (`CheckConsent`, `DataMinimization`), Minimization (Anonymization + Pseudonymization engines + DataMinimizer service), Models, Monitoring (compliance monitor + 4 default checks: ConsentValidity, DpiaCompletion, DsrTimeliness, RetentionPolicy), Portability (service, data packager, JSON / CSV / XML formatters, user + consent exporters), Reporting (generator + ComplianceStatusReport), Traits (Auditable, HasConsent, PrivacyByDesign), Validation, plus 5 Contracts.

**Other src/ surfaces** — 5 console commands, 4 HTTP controllers under `Compliance/`, 3 jobs, 8 events.

**`routes/`, `config/`, `database/`** — `routes/compliance.php` (config-gated), `config/artisanpack/compliance.php` (lifted out of `config/security-compliance.php`), 20 flattened migrations.

## ServiceProvider

`ComplianceServiceProvider` does the full bootstrap:
- `mergeConfigFrom('artisanpack.compliance')`, publishable under tag `compliance-config`
- `loadMigrationsFrom` + `loadRoutesFrom` (config-gated on `routes.enabled`)
- ~12 service singletons (Consent*, Anonymization, Pseudonymization, DataMinimizer, Erasure, Portability, RiskCalculator, ProcessingActivity, Dpia, ComplianceMonitor, ReportGenerator)
- Middleware aliases `check.consent` and `data.minimization`, both gated on per-domain config
- Out-of-the-box logging listeners for the 8 compliance events
- Default-deny `viewComplianceDashboard` gate (apps override in their AuthServiceProvider)

## Config rewrites

- `security-compliance.X` → `artisanpack.compliance.X`
- `security.compliance.X` → `artisanpack.compliance.X`

## Pre-PR CodeRabbit CLI iterations

Per the new "run CR CLI before pushing" workflow, ran the CLI three times locally and addressed **14 findings** before opening this PR. CR usage credits ran out partway through the 4th pass, so the cloud review will pick up anything still outstanding.

| Pass | Findings fixed |
|---|---|
| 1 | ConsentManager calculateExpiration honors policy retention_period; ConsentValidityCheck eager-loads policies + only counts no-warning records as compliant; RetentionPolicyCheck verifies model_class is an Eloquent\\Model subclass; PurgeExpiredData closes TOCTOU between count + purge |
| 2 | UserDataExporter validates auth user model class before `::find()`; switched transformItem from deny-list to allow-list against `getSchema()['properties']` |
| 3 | ErasureService createLog initializes status=`in_progress`; backup_reference encoding goes through a JSON_THROW_ON_ERROR helper; generateCertificate uses JSON_THROW_ON_ERROR; rollback coerces malformed json_decode to []; CookieConsentHandler uses JSON_THROW_ON_ERROR for the consent cookie payload; AnonymizationEngine::generalizeDate try/catch around DateTime; AnonymizationEngine::addNoise switched mt_rand() → random_int() and clamps the uniform variate away from ±0.5 to avoid log(0) / -INF |

## Pre-existing bugs fixed during extraction

- `src/Compliance/Traits/Auditable.php` had a copy-paste-duplicated `$data` array initialization in `logAuditEvent()` that produced a parse error. Removed the duplicate.

## Verification

- [x] `vendor/bin/php-cs-fixer fix` — clean
- [x] `vendor/bin/phpcs` — clean
- [x] `vendor/bin/pest` — 5 placeholder tests passing
- [x] CR CLI: 3 passes, 14 findings fixed, baseline cleaner than the prior Wave 6 PRs

## Test plan

- [ ] CI green
- [ ] CodeRabbit cloud review pass
- [ ] Smoke test: `composer require artisanpack-ui/compliance:dev-feature/extract-content-from-security` against a Laravel 11 app, run migrations, configure a `viewComplianceDashboard` gate, hit the compliance dashboard route, exercise consent + erasure flows.

## Wave 6 — fully shipped after this lands

| Package | Status |
|---|---|
| `security-auth` | ✅ shipped |
| `security-advanced-auth` | ✅ shipped |
| `secure-uploads` | ✅ shipped |
| `security-analytics` | ✅ shipped |
| `compliance` scaffold | ✅ shipped via PR #12 |
| `compliance` content | 👋 this PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full compliance suite: consent management, cookie preferences/banner, verification, reconsent and audit logs.
  * Data subject rights: erasure workflows with handler registry, certificates, verification/cancellation; portability exports (JSON/XML/ZIP-CSV) with storage, download limits.
  * DPIA & processing activities: assessments, risks, mitigations, scoring and review workflows.
  * Monitoring & reporting: scheduled checks, violations, compliance scoring, admin dashboard, report generation and CLI jobs.
  * Data minimization: anonymization/pseudonymization engines, collection policies, retention/purge tooling and enforcing middleware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->