### PR TITLE
feat: add Laravel 13 support (widen illuminate/support constraint)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,16 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'release/**'
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - 'release/**'
+
+permissions:
+  contents: read
 
 jobs:
   lint:
@@ -14,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@8358ee0e2e8afe63c2fb8253d1d52085811ab1e5 # v2
@@ -45,15 +54,27 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    name: Test
+    name: Test (L${{ matrix.laravel }} / PHP ${{ matrix.php }})
+
+    strategy:
+      fail-fast: true
+      matrix:
+        laravel: ['12', '13']
+        php: ['8.2', '8.3', '8.4']
+        exclude:
+          # Laravel 13 requires PHP 8.3+
+          - laravel: '13'
+            php: '8.2'
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@8358ee0e2e8afe63c2fb8253d1d52085811ab1e5 # v2
         with:
-          php-version: '8.4'
+          php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
           coverage: none
 
@@ -65,11 +86,32 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
+          key: ${{ runner.os }}-php${{ matrix.php }}-laravel${{ matrix.laravel }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-php${{ matrix.php }}-laravel${{ matrix.laravel }}-composer-
+
+      - name: Align composer platform PHP with the matrix
+        # The repo's composer.json pins config.platform.php to 8.2 so local
+        # composer.lock stays installable on the lowest supported PHP. In CI we
+        # need composer to resolve against the matrix PHP so the Laravel 13 leg
+        # (PHP 8.3+) can install.
+        run: composer config platform.php ${{ matrix.php }}
+
+      - name: Remove lint-only dev dependencies
+        # The code-style toolchain caps illuminate/support at ^12, which would
+        # block the Laravel 13 leg. Linting runs in its own job, so the test
+        # matrix does not need these packages.
+        run: >
+          composer remove --dev --no-update --no-interaction
+          friendsofphp/php-cs-fixer
+          artisanpack-ui/code-style
+          artisanpack-ui/code-style-pint
+          dealerdirect/phpcodesniffer-composer-installer
+
+      - name: Pin Laravel version
+        run: composer require "illuminate/support:^${{ matrix.laravel }}.0" --no-update --no-interaction
 
       - name: Install dependencies
-        run: composer install --no-interaction --prefer-dist
+        run: composer update --no-interaction --prefer-dist
 
       - name: Run Unit tests
         env:

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
   ],
   "require": {
     "php": "^8.2",
-    "illuminate/support": "^10.0|^11.0|^12.0",
+    "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
     "artisanpack-ui/core": "^1.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
     "friendsofphp/php-cs-fixer": "^3.75",
     "laravel/pint": "^1.26",
-    "orchestra/testbench": "^10.2",
+    "orchestra/testbench": "^10.2|^11.0",
     "pestphp/pest": "^3.8|^4.0",
     "pestphp/pest-plugin-laravel": "^3.2|^4.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -47,8 +47,8 @@
     "friendsofphp/php-cs-fixer": "^3.75",
     "laravel/pint": "^1.26",
     "orchestra/testbench": "^10.2",
-    "pestphp/pest": "^3.8",
-    "pestphp/pest-plugin-laravel": "^3.2"
+    "pestphp/pest": "^3.8|^4.0",
+    "pestphp/pest-plugin-laravel": "^3.2|^4.0"
   },
   "scripts": {
     "lint": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "67ca324e25eb45c36d5c6892e05dc705",
+    "content-hash": "4aad62235b68326c4617a544492235d1",
     "packages": [
         {
             "name": "artisanpack-ui/core",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4aad62235b68326c4617a544492235d1",
+    "content-hash": "9354fa1c267aadd41502a51cd0765e0f",
     "packages": [
         {
             "name": "artisanpack-ui/core",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b8b079af8165022f58fcdb32b6716e60",
+    "content-hash": "67ca324e25eb45c36d5c6892e05dc705",
     "packages": [
         {
             "name": "artisanpack-ui/core",
@@ -11437,5 +11437,5 @@
     "platform-overrides": {
         "php": "8.2"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
## Description

Widen the `illuminate/support` constraint to accept Laravel 13 so consumer apps (and the `security-full` meta-package, which pulls `compliance` in transitively) can adopt Laravel 13. PHP `^8.2` is preserved — Composer's solver picks Laravel 10/11/12 on PHP 8.2 and only picks Laravel 13 on PHP 8.3+.

**Closes:** #15

## Type of Change

- [x] Enhancement (improves existing functionality)

## Related Issue

**Issue:** #15

## Motivation and Context

`compliance` v1.0.0 capped `illuminate/support` at `^12`, silently blocking Laravel 13 in any app that pulls it in (including via `security-full`). Sibling packages (`rbac`, `security-auth`, `secure-uploads`) already shipped this same widening, so this restores ecosystem parity.

## Changes Made

- `composer.json` — widened `illuminate/support` to `^10.0|^11.0|^12.0|^13.0`. PHP constraint left at `^8.2`.
- `composer.lock` — regenerated content hash (no dependency upgrades).
- `.github/workflows/ci.yml` — mirrored `rbac`'s pattern:
  - Added `release/**` to push + PR triggers.
  - Added `permissions: contents: read` and `persist-credentials: false` (hardening).
  - Test job now runs a matrix: Laravel `12`/`13` × PHP `8.2`/`8.3`/`8.4`, excluding L13/PHP 8.2 (Laravel 13 requires PHP 8.3+).
  - Matrix aligns `config.platform.php` to the matrix PHP, strips lint-only dev deps (which cap `illuminate/support` at ^12), pins `illuminate/support` to the matrix Laravel, then runs `composer update`.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- PHP Version: 8.4.22
- Composer: 2.9.0
- Project Version: 1.0.1 (release branch)

**Tests Performed:**
1. `composer validate --no-check-publish` — clean (only the pre-existing `version` field warning).
2. `composer update illuminate/support` — resolves cleanly.
3. `./vendor/bin/pest tests/Unit --no-coverage` — 2 passed.
4. `./vendor/bin/pest tests/Feature --no-coverage` — 12 passed.
5. `./vendor/bin/php-cs-fixer fix --dry-run --diff` — clean.
6. `./vendor/bin/phpcs src/ database/ tests/ config/` — clean.

Full matrix verification (Laravel 13 legs on PHP 8.3 / 8.4) will run on CI for this PR.

## Accessibility Tests Run

N/A — composer constraint and CI-only change. No runtime UI surface.

## Tests Added

- [x] All tests passing
- [ ] Unit tests added/updated — not needed (no behavior change)
- [ ] Integration tests added/updated — not needed (no behavior change)

**Test details:** No new tests; the CI matrix itself is the verification surface for the constraint widening.

## Documentation

- [ ] N/A — composer constraint change only.

## Pre-Submission Checklist

- [x] Backwards compatible (existing PHP 8.2 / L10-12 users unaffected)
- [x] Followed sibling-package pattern (`rbac`, `security-auth`)
- [x] CI matrix updated to exercise the new Laravel 13 leg
- [x] Targeted at `release/1.0.1` (not `main`)

## Follow-up

After this ships as 1.0.1, `artisanpack-ui/security-full`'s constraint on `compliance` may need a bump per the issue's acceptance criteria.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores
* Updated the CI workflow to run linting and tests on pushes and pull requests to main and release branches, with safer checkout permissions/credential handling
* Expanded Composer handling to be matrix-aware (cache keying, platform PHP resolution, and dependency selection) and switched installation to an update workflow per leg
* Added Laravel 13 compatibility to dependency constraints, including broader Pest/Pest plugin support

## Tests
* Run unit and feature tests across a PHP (8.2–8.4) and Laravel (12–13) matrix, excluding unsupported combinations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->