### PR TITLE
Release v1.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,16 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'release/**'
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - 'release/**'
+
+permissions:
+  contents: read
 
 jobs:
   lint:
@@ -14,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@8358ee0e2e8afe63c2fb8253d1d52085811ab1e5 # v2
@@ -45,15 +54,27 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    name: Test
+    name: Test (L${{ matrix.laravel }} / PHP ${{ matrix.php }})
+
+    strategy:
+      fail-fast: true
+      matrix:
+        laravel: ['12', '13']
+        php: ['8.2', '8.3', '8.4']
+        exclude:
+          # Laravel 13 requires PHP 8.3+
+          - laravel: '13'
+            php: '8.2'
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@8358ee0e2e8afe63c2fb8253d1d52085811ab1e5 # v2
         with:
-          php-version: '8.4'
+          php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
           coverage: none
 
@@ -65,11 +86,32 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-
+          key: ${{ runner.os }}-php${{ matrix.php }}-laravel${{ matrix.laravel }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-php${{ matrix.php }}-laravel${{ matrix.laravel }}-composer-
+
+      - name: Align composer platform PHP with the matrix
+        # The repo's composer.json pins config.platform.php to 8.2 so local
+        # composer.lock stays installable on the lowest supported PHP. In CI we
+        # need composer to resolve against the matrix PHP so the Laravel 13 leg
+        # (PHP 8.3+) can install.
+        run: composer config platform.php ${{ matrix.php }}
+
+      - name: Remove lint-only dev dependencies
+        # The code-style toolchain caps illuminate/support at ^12, which would
+        # block the Laravel 13 leg. Linting runs in its own job, so the test
+        # matrix does not need these packages.
+        run: >
+          composer remove --dev --no-update --no-interaction
+          friendsofphp/php-cs-fixer
+          artisanpack-ui/code-style
+          artisanpack-ui/code-style-pint
+          dealerdirect/phpcodesniffer-composer-installer
+
+      - name: Pin Laravel version
+        run: composer require "illuminate/support:^${{ matrix.laravel }}.0" --no-update --no-interaction
 
       - name: Install dependencies
-        run: composer install --no-interaction --prefer-dist
+        run: composer update --no-interaction --prefer-dist
 
       - name: Run Unit tests
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-06-14
+
+### Added
+
+- **Laravel 13 support** — widened `illuminate/support` constraint to `^10.0|^11.0|^12.0|^13.0` so consumer apps (and `artisanpack-ui/security-full`, which pulls Compliance in transitively) can adopt Laravel 13. PHP `^8.2` is preserved; Composer's solver picks Laravel 10/11/12 on PHP 8.2 and only picks Laravel 13 on PHP 8.3+. (#15)
+
+### Changed
+
+- **CI matrix** — `Test` job now runs across Laravel 12/13 × PHP 8.2/8.3/8.4 (excluding L13/PHP 8.2, which Laravel 13 itself forbids). Workflow also gained `release/**` triggers and least-privilege `permissions: contents: read` + `persist-credentials: false` hardening.
+- **Dev dependency constraints widened to unblock the Laravel 13 leg** —
+  - `pestphp/pest` → `^3.8|^4.0`
+  - `pestphp/pest-plugin-laravel` → `^3.2|^4.0`
+  - `orchestra/testbench` → `^10.2|^11.0`
+
 ## [1.0.0] - 2026-05-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Register implementations in your service provider; the orchestrators discover th
 ## Requirements
 
 - PHP 8.2+
-- Laravel 10 / 11 / 12
+- Laravel 10 / 11 / 12 / 13 (Laravel 13 requires PHP 8.3+)
 
 ## Sibling packages
 

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
   ],
   "require": {
     "php": "^8.2",
-    "illuminate/support": "^10.0|^11.0|^12.0",
+    "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
     "artisanpack-ui/core": "^1.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
     "friendsofphp/php-cs-fixer": "^3.75",
     "laravel/pint": "^1.26",
-    "orchestra/testbench": "^10.2",
+    "orchestra/testbench": "^10.2|^11.0",
     "pestphp/pest": "^3.8|^4.0",
     "pestphp/pest-plugin-laravel": "^3.2|^4.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Compliance toolkit for Laravel — GDPR / CCPA / LGPD consent management, data subject rights (erasure + portability), DPIA / processing-activity records, data minimization (anonymization + pseudonymization), retention policies, compliance monitoring + reporting.",
   "type": "library",
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "keywords": [
     "laravel",
     "compliance",

--- a/composer.json
+++ b/composer.json
@@ -47,8 +47,8 @@
     "friendsofphp/php-cs-fixer": "^3.75",
     "laravel/pint": "^1.26",
     "orchestra/testbench": "^10.2",
-    "pestphp/pest": "^3.8",
-    "pestphp/pest-plugin-laravel": "^3.2"
+    "pestphp/pest": "^3.8|^4.0",
+    "pestphp/pest-plugin-laravel": "^3.2|^4.0"
   },
   "scripts": {
     "lint": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "67ca324e25eb45c36d5c6892e05dc705",
+    "content-hash": "4aad62235b68326c4617a544492235d1",
     "packages": [
         {
             "name": "artisanpack-ui/core",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4aad62235b68326c4617a544492235d1",
+    "content-hash": "9354fa1c267aadd41502a51cd0765e0f",
     "packages": [
         {
             "name": "artisanpack-ui/core",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b8b079af8165022f58fcdb32b6716e60",
+    "content-hash": "67ca324e25eb45c36d5c6892e05dc705",
     "packages": [
         {
             "name": "artisanpack-ui/core",
@@ -11437,5 +11437,5 @@
     "platform-overrides": {
         "php": "8.2"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9354fa1c267aadd41502a51cd0765e0f",
+    "content-hash": "aab362fabc7f20a088a72a549d06a0e0",
     "packages": [
         {
             "name": "artisanpack-ui/core",

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 - PHP 8.2+
-- Laravel 10, 11, or 12
+- Laravel 10, 11, 12, or 13 (Laravel 13 requires PHP 8.3+)
 - A database supported by Eloquent — SQLite, MySQL, PostgreSQL, SQL Server. The schema uses standard column types (string / text / json / decimal / timestamp / boolean) so any current Laravel-supported driver works.
 
 ## Install via Composer


### PR DESCRIPTION
## Release Information

- **Release Version:** v1.0.1
- **Release Date:** 2026-06-14
- **Release Type:** Minor (additive, backwards compatible)
- **Release Branch:** `release/1.0.1`
- **Target Branch:** `main`

## Release Summary

Adds Laravel 13 support to `artisanpack-ui/compliance` and brings the CI matrix in line with the rest of the ArtisanPack-UI ecosystem (`rbac`, `security-auth`). Consumer apps and the `security-full` meta-package (which pulls Compliance in transitively) can now adopt Laravel 13. PHP `^8.2` is preserved — Composer's solver picks Laravel 10/11/12 on PHP 8.2 and only picks Laravel 13 on PHP 8.3+, so existing users are unaffected.

## Changelog

### Added

- **Laravel 13 support** — widened `illuminate/support` constraint to `^10.0|^11.0|^12.0|^13.0`. (#15)

### Changed

- **CI matrix** — `Test` job now runs across Laravel 12/13 × PHP 8.2/8.3/8.4 (excluding L13/PHP 8.2). Workflow also gained `release/**` triggers and least-privilege `permissions: contents: read` + `persist-credentials: false` hardening.
- **Dev dependency constraints widened to unblock the L13 leg:**
  - `pestphp/pest` → `^3.8|^4.0`
  - `pestphp/pest-plugin-laravel` → `^3.2|^4.0`
  - `orchestra/testbench` → `^10.2|^11.0`
- **README + docs/installation.md** — now advertise Laravel 13 (with PHP 8.3+ note).

### Deprecated

_None._

### Removed

_None._

### Fixed

_None._

### Security

_None._

## Issues and Pull Requests

**Issues Fixed:**
- Closes #15

**Related PRs:**
- #16 (merged into `release/1.0.1`)

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below

**Breaking changes:** None — constraints are widened, not narrowed. PHP `^8.2` and existing Laravel 10/11/12 support are preserved.

**Migration guide:** N/A.

## Testing Checklist

- [x] All automated tests passing — 14 Pest tests, 27 assertions, across L12/13 × PHP 8.2/8.3/8.4 matrix
- [x] Manual testing completed — sandbox-simulated L13/PHP 8.3 install path locally before pushing
- [x] Security scan completed — `composer audit` reviewed (see notes below)
- [x] Database migrations tested (no migration changes in this release)

**Testing notes:** All five matrix legs (L12/PHP 8.2, L12/PHP 8.3, L12/PHP 8.4, L13/PHP 8.3, L13/PHP 8.4) passed on PR #16 before merge.

## Documentation Checklist

- [x] CHANGELOG updated — new `## [1.0.1] - 2026-06-14` section
- [x] README updated — Laravel 13 added to Requirements
- [x] docs/installation.md updated — Laravel 13 added to Requirements with PHP 8.3+ note
- [x] No API docs needed (no API changes)
- [x] No migration guide needed (no breaking changes)

## Pre-Release Checklist

- [x] Version number updated in all necessary files (composer.json → 1.0.1)
- [ ] Git tag prepared: `v1.0.1` (apply after merge)
- [x] Release branch updated: `release/1.0.1`
- [x] Dependencies updated and tested — lock file in sync
- [x] Deployment plan reviewed (Packagist will pick up `v1.0.1` tag automatically)
- [x] Rollback plan prepared (revert is safe — additive change only)

## Deployment

**Deployment steps:**
1. Merge this PR into `main`.
2. Tag `main`: `git tag v1.0.1 && git push origin v1.0.1`.
3. Packagist auto-syncs from the tag.

**Rollback plan:**
1. Delete the `v1.0.1` tag from origin and local: `git tag -d v1.0.1 && git push origin :refs/tags/v1.0.1`.
2. Packagist will continue serving `v1.0.0` for `^1.0` consumers.

### Configuration changes
None.

### Environment variables
None.

## Post-Release Tasks

- [ ] Tag created: `v1.0.1`
- [ ] Release notes published on GitHub Releases
- [ ] Verify Packagist picked up the tag
- [ ] Consider whether `artisanpack-ui/security-full`'s constraint on `compliance` needs a bump (per #15 acceptance criteria)

## Notes

### Dependency Audit Results

- **Lock file:** in sync with `composer.json` (verified via `composer validate`).
- **Outdated direct deps (informational, none > 1 major behind):**
  - `artisanpack-ui/code-style` 1.1.0 → 1.1.1 (patch)
  - `artisanpack-ui/code-style-pint` 1.1.0 → 1.1.1 (patch)
  - `artisanpack-ui/core` 1.1.0 → 1.2.0 (minor)
  - `friendsofphp/php-cs-fixer` 3.95.1 → 3.95.7 (patch)
- **Security advisories:** 14 advisories across `guzzlehttp/psr7`, `laravel/framework`, `symfony/http-foundation`, `symfony/http-kernel`, `symfony/mailer`, `symfony/mime`, `symfony/polyfill-intl-idn`, `symfony/routing`, `symfony/yaml`. **All affected packages are transitive dev-only dependencies** (pulled in by `orchestra/testbench` / `pestphp/pest-plugin-laravel` for the test environment); none ship with the package or affect production consumers. Severities range from low to high. Worth tracking, but not a blocker for 1.0.1.

### Why this release

`compliance` 1.0.0 silently capped the `security-full` meta-package at Laravel 12 because `illuminate/support` was constrained to `^12`. This release restores ecosystem parity with `rbac` and `security-auth`, which already shipped the same widening.

---

**Release Manager:** @jacobmartella

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Laravel 13 with minimum PHP 8.3 requirement.
  * Enhanced testing framework compatibility across multiple versions.

* **Documentation**
  * Updated installation and requirements documentation.

* **Chores**
  * Version bumped to 1.0.1.
  * Expanded development dependency versions for broader framework support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->