### PR TITLE
Release v1.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,11 +60,7 @@ jobs:
       fail-fast: true
       matrix:
         laravel: ['12', '13']
-        php: ['8.2', '8.3', '8.4']
-        exclude:
-          # Laravel 13 requires PHP 8.3+
-          - laravel: '13'
-            php: '8.2'
+        php: ['8.3', '8.4']
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -90,10 +86,8 @@ jobs:
           restore-keys: ${{ runner.os }}-php${{ matrix.php }}-laravel${{ matrix.laravel }}-composer-
 
       - name: Align composer platform PHP with the matrix
-        # The repo's composer.json pins config.platform.php to 8.2 so local
-        # composer.lock stays installable on the lowest supported PHP. In CI we
-        # need composer to resolve against the matrix PHP so the Laravel 13 leg
-        # (PHP 8.3+) can install.
+        # Ensure composer resolves against the matrix PHP even if a
+        # future composer.json pins a platform floor.
         run: composer config platform.php ${{ matrix.php }}
 
       - name: Remove lint-only dev dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Authorization gate on draft persistence** — `AiTools::saveDraft` now checks a `manageComplianceAiDrafts` Gate (default-deny, override in the app's `AuthServiceProvider`) before writing to `compliance_ai_drafts`. Previously any browser session that reached a page mounting the component could persist forged drafts.
+- **Configurable auth guard** — the `/api/v1/compliance/ai/*` REST routes now read the guard from `config('artisanpack.compliance.ai.guard')` (default `sanctum`, override via `COMPLIANCE_AI_GUARD`). Consumer apps without Sanctum can point at `web` or any configured guard, replacing the previous hard-coded `auth:sanctum` that 500'd when Sanctum wasn't installed.
+
+### Fixed
+
+- **Feature-toggle bypass on save** — `AiTools::saveDraft` now rejects saves when the feature is toggled OFF in the FeatureRegistry (was only checking `AI_FEATURE_KEYS` membership).
+- **DPIA risk↔mitigation linkage** — `DpiaAssistanceAgent::validateOutput` now enforces that every enumerated risk has a matching mitigation entry (linked by `risk_title`). Previously the "every risk must have a mitigation" invariant declared in the prompt was not verified in code, so a partial DPIA could ship as valid output.
+- **Privacy-policy input validation** — `PrivacyPolicyDraftAgent` now rejects non-array elements in `processing_activities`, closing a Livewire-only path (REST callers were already covered by the FormRequest) that could send mixed lists to the prompter.
+- **Consent-text short label** — `ConsentTextSuggestionAgent` now throws `FeatureError` when the model returns an empty `short_label`. An unlabelled consent checkbox does not meet the "clear affirmative act" standard.
+
+### Added
+
+- **AI integration** — three high-stakes agents powered by `artisanpack-ui/ai` (soft dependency):
+  - `compliance.privacy_policy_draft` (`PrivacyPolicyDraftAgent`, default model `claude-opus-4-7`) — drafts a starter privacy policy from declared processing activities.
+  - `compliance.dpia_assistance` (`DpiaAssistanceAgent`, default model `claude-opus-4-7`) — enumerates risks, mitigations, and stakeholder impacts for a DPIA.
+  - `compliance.consent_text` (`ConsentTextSuggestionAgent`, default model `claude-sonnet-4-6`) — suggests plain-language consent text with reading-level score and jurisdiction notes.
+- **Guardrail contract** — every agent forces `requires_legal_review: true` and a non-empty `review_checklist` on its output; the host UI is required to render an un-dismissable "requires legal review" banner and an acknowledgement checkbox before the draft body is shown.
+- **Append-only draft storage** — new `compliance_ai_drafts` table + `AiDraft` model preserve every generation as a new row; the model throws on any attempt to update an existing draft.
+- **Trigger surfaces** — Livewire component `ap-compliance-ai-tools` for Blade/Livewire hosts, plus `/api/v1/compliance/ai/*` REST endpoints (Sanctum-gated) for React and Vue hosts. Both are skipped when `artisanpack-ui/ai` is not installed. (#18, #19, #20)
+
 ## [1.0.1] - 2026-06-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-09
+
 ### Changed
 
 - **PHP 8.2 support dropped** — minimum PHP is now 8.3. The AI features added in this release depend on `artisanpack-ui/ai`, which requires PHP 8.3+, so the CI matrix (and the package's own `require`) can no longer honor 8.2. Apps still on PHP 8.2 should stay on `1.0.x`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **PHP 8.2 support dropped** — minimum PHP is now 8.3. The AI features added in this release depend on `artisanpack-ui/ai`, which requires PHP 8.3+, so the CI matrix (and the package's own `require`) can no longer honor 8.2. Apps still on PHP 8.2 should stay on `1.0.x`.
+
 ### Security
 
 - **Authorization gate on draft persistence** — `AiTools::saveDraft` now checks a `manageComplianceAiDrafts` Gate (default-deny, override in the app's `AuthServiceProvider`) before writing to `compliance_ai_drafts`. Previously any browser session that reached a page mounting the component could persist forged drafts.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,95 @@ The package ships pluggable interfaces so you can add organization-specific beha
 
 Register implementations in your service provider; the orchestrators discover them via the container.
 
+## AI features
+
+The compliance package ships three optional AI trigger surfaces powered by [`artisanpack-ui/ai`](https://github.com/ArtisanPack-UI/ai). Every one of these is **high-stakes** — output must be reviewed by qualified legal counsel before it goes anywhere near production.
+
+| Feature key | Agent | Default model | Purpose |
+|---|---|---|---|
+| `compliance.privacy_policy_draft` | `PrivacyPolicyDraftAgent` | `claude-opus-4-7` | Draft a starter privacy policy from declared processing activities. |
+| `compliance.dpia_assistance` | `DpiaAssistanceAgent` | `claude-opus-4-7` | Enumerate risks, mitigations, and stakeholder impacts for a DPIA. |
+| `compliance.consent_text` | `ConsentTextSuggestionAgent` | `claude-sonnet-4-6` | Suggest plain-language consent text with reading-level score and jurisdiction notes. |
+
+### Non-negotiable guardrails
+
+Every host that surfaces these agents MUST:
+
+1. **Render an un-dismissable "requires legal review" banner** on every draft. The banner is not decorative — every agent output carries `requires_legal_review: true` and a `review_checklist` array, and both must be shown to the user before they can view the body.
+2. **Gate viewing the draft behind an acknowledgement checkbox**. Users cannot see the generated content until they confirm they understand the draft is not legal advice.
+3. **Never overwrite an existing draft**. Persist every run as a new `AiDraft` row — the model itself blocks updates via a `booted()` guard. This preserves the full version history for legal review.
+
+### Installing the AI dependency
+
+`artisanpack-ui/ai` is a soft dependency — the compliance package boots without it, and the AI surfaces stay unregistered. To enable them:
+
+```bash
+composer require artisanpack-ui/ai
+```
+
+Then set your provider credentials (see the `ai` package README) and toggle the features in `config/artisanpack/ai.php`:
+
+```php
+'features' => [
+    'compliance.privacy_policy_draft' => [ 'enabled' => true ],
+    'compliance.dpia_assistance'      => [ 'enabled' => true ],
+    'compliance.consent_text'         => [ 'enabled' => true ],
+],
+```
+
+### Triggering an agent from Livewire
+
+```blade
+<livewire:ap-compliance-ai-tools />
+
+<button
+    wire:click="$dispatch('compliance-ai:suggest-consent-text', {
+        payload: {
+            purpose: 'Send weekly product update emails',
+            data_categories: ['email address', 'engagement metrics'],
+            audience: 'general public',
+            jurisdiction: 'EU',
+        }
+    })"
+>Suggest consent text</button>
+```
+
+Listen for the result on the browser side:
+
+```js
+Livewire.on('compliance-ai:compliance.consent_text:success', ({ output }) => {
+    // Render the "requires legal review" banner first.
+    // Then render the acknowledgement checkbox.
+    // Only reveal `output.consent_text` after the user acknowledges.
+});
+```
+
+Saving a draft after acknowledgement:
+
+```js
+Livewire.dispatch('compliance-ai:save-draft', {
+    featureKey: 'compliance.consent_text',
+    output: agentOutput,
+    subjectKey: 'marketing-email-consent',
+    metadata: { acknowledged: true, reviewer: 'jane@acme.example' },
+});
+```
+
+The Livewire component rejects any save where `metadata.acknowledged` is not `true`.
+
+### Triggering from React or Vue
+
+Hit the REST endpoints directly — they are mounted at `/api/v1/compliance/ai/*` and gated by `auth:sanctum`:
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/api/v1/compliance/ai/features` | GET | Feature-toggle state map. |
+| `/api/v1/compliance/ai/privacy-policy-draft` | POST | Run `PrivacyPolicyDraftAgent`. |
+| `/api/v1/compliance/ai/dpia-assistance` | POST | Run `DpiaAssistanceAgent`. |
+| `/api/v1/compliance/ai/consent-text` | POST | Run `ConsentTextSuggestionAgent`. |
+
+Every response follows the shape `{ feature: string, output: object }` on success or `{ feature: string, error: string, message: string }` on failure. Error codes: `feature_disabled` (403), `missing_credentials` (503), `invalid_input` (422), `internal_error` (500).
+
 ## Documentation
 
 - [Getting Started](docs/getting-started.md)

--- a/README.md
+++ b/README.md
@@ -219,8 +219,8 @@ Every response follows the shape `{ feature: string, output: object }` on succes
 
 ## Requirements
 
-- PHP 8.2+
-- Laravel 10 / 11 / 12 / 13 (Laravel 13 requires PHP 8.3+)
+- PHP 8.3+
+- Laravel 10 / 11 / 12 / 13
 
 ## Sibling packages
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Compliance toolkit for Laravel — GDPR / CCPA / LGPD consent management, data subject rights (erasure + portability), DPIA / processing-activity records, data minimization (anonymization + pseudonymization), retention policies, compliance monitoring + reporting.",
   "type": "library",
   "license": "MIT",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "keywords": [
     "laravel",
     "compliance",

--- a/composer.json
+++ b/composer.json
@@ -41,14 +41,19 @@
     "artisanpack-ui/core": "^1.0"
   },
   "require-dev": {
+    "artisanpack-ui/ai": "^1.0",
     "artisanpack-ui/code-style": "^1.1",
     "artisanpack-ui/code-style-pint": "^1.1",
     "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
     "friendsofphp/php-cs-fixer": "^3.75",
     "laravel/pint": "^1.26",
+    "livewire/livewire": "^3.6",
     "orchestra/testbench": "^10.2|^11.0",
     "pestphp/pest": "^3.8|^4.0",
     "pestphp/pest-plugin-laravel": "^3.2|^4.0"
+  },
+  "suggest": {
+    "artisanpack-ui/ai": "Recommended ^1.0 — enables the high-stakes compliance AI agents (privacy-policy draft, DPIA assistance, consent-text suggestion). Without it the `aiFeatures()` service-provider hook is a no-op and the AI trigger surfaces (Livewire component + REST endpoints) stay hidden."
   },
   "scripts": {
     "lint": [
@@ -64,9 +69,6 @@
     "allow-plugins": {
       "pestphp/pest-plugin": true,
       "dealerdirect/phpcodesniffer-composer-installer": true
-    },
-    "platform": {
-      "php": "8.2"
     }
   },
   "extra": {

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     }
   ],
   "require": {
-    "php": "^8.2",
+    "php": "^8.3",
     "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
     "artisanpack-ui/core": "^1.0"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,38 +4,46 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aab362fabc7f20a088a72a549d06a0e0",
+    "content-hash": "b9ac6c50977ee2239b3f6c8ba50f8806",
     "packages": [
         {
             "name": "artisanpack-ui/core",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ArtisanPack-UI/core.git",
-                "reference": "16e91edb542948ee335c618a17fdc60f8593d671"
+                "reference": "bb7055c4b250612d987398f990b5537fbc28865b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ArtisanPack-UI/core/zipball/16e91edb542948ee335c618a17fdc60f8593d671",
-                "reference": "16e91edb542948ee335c618a17fdc60f8593d671",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/core/zipball/bb7055c4b250612d987398f990b5537fbc28865b",
+                "reference": "bb7055c4b250612d987398f990b5537fbc28865b",
                 "shasum": ""
             },
             "require": {
-                "illuminate/support": "^11.0|^12.0",
+                "composer/semver": "^3.0",
+                "illuminate/support": "^11.0|^12.0|^13.0",
                 "laravel/prompts": "^0.3",
                 "php": "^8.2"
             },
             "require-dev": {
+                "artisanpack-ui/code-style": "^1.1",
+                "artisanpack-ui/code-style-pint": "^1.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "friendsofphp/php-cs-fixer": "^3.75",
                 "laravel/pint": "^1.27",
-                "orchestra/testbench": "^10.2",
-                "pestphp/pest": "^3.8",
-                "pestphp/pest-plugin-laravel": "^3.1"
+                "orchestra/testbench": "^9.0|^10.0|^11.0",
+                "pestphp/pest": "^3.8|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.1|^4.0",
+                "squizlabs/php_codesniffer": "3.11.3"
             },
             "type": "library",
             "extra": {
                 "laravel": {
                     "aliases": {
-                        "Core": "ArtisanPackUI\\Core\\Facades\\Core"
+                        "Core": "ArtisanPackUI\\Core\\Facades\\Core",
+                        "ArtisanPackLog": "ArtisanPackUI\\Core\\Facades\\ArtisanPackLog",
+                        "ArtisanPackConfig": "ArtisanPackUI\\Core\\Facades\\ArtisanPackConfig"
                     },
                     "providers": [
                         "ArtisanPackUI\\Core\\CoreServiceProvider"
@@ -63,9 +71,9 @@
             "description": "Supplies the core functionality for ArtisanPack UI that needs to be shared across all packages.",
             "support": {
                 "issues": "https://github.com/ArtisanPack-UI/core/issues",
-                "source": "https://github.com/ArtisanPack-UI/core/tree/v1.1.0"
+                "source": "https://github.com/ArtisanPack-UI/core/tree/v1.2.0"
             },
-            "time": "2026-01-10T02:20:40+00:00"
+            "time": "2026-05-24T02:53:50+00:00"
         },
         {
             "name": "brick/math",
@@ -195,6 +203,83 @@
                 }
             ],
             "time": "2024-02-09T16:56:22+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^3 || ^7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-20T19:15:30+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -704,25 +789,26 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.0",
+            "version": "7.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+                "reference": "aef242412e13128b5049864867bb49fc37dd39de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/aef242412e13128b5049864867bb49fc37dd39de",
+                "reference": "aef242412e13128b5049864867bb49fc37dd39de",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.3",
-                "guzzlehttp/psr7": "^2.8",
+                "guzzlehttp/promises": "^2.5.1",
+                "guzzlehttp/psr7": "^2.12.4",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -730,9 +816,10 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
-                "guzzle/client-integration-tests": "3.0.2",
+                "guzzle/client-integration-tests": "3.0.3",
+                "guzzlehttp/test-server": "^0.6",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -810,7 +897,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.14.0"
             },
             "funding": [
                 {
@@ -826,28 +913,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T22:36:01+00:00"
+            "time": "2026-07-08T22:54:09+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.3.0",
+            "version": "2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/9ad1e4fc607446a055b95870c7f668e93b5cff29",
+                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5 || ^8.0"
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "type": "library",
             "extra": {
@@ -893,7 +981,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.1"
             },
             "funding": [
                 {
@@ -909,27 +997,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:34:08+00:00"
+            "time": "2026-07-08T15:48:39+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.9.0",
+            "version": "2.12.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
+                "reference": "51e27f9e2b332ab3e72f4520d5ff4f3c68c3577c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/51e27f9e2b332ab3e72f4520d5ff4f3c68c3577c",
+                "reference": "51e27f9e2b332ab3e72f4520d5ff4f3c68c3577c",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0"
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -937,9 +1027,9 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "0.9.0",
+                "http-interop/http-factory-tests": "1.1.0",
                 "jshttp/mime-db": "1.54.0.1",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -1010,7 +1100,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.12.4"
             },
             "funding": [
                 {
@@ -1026,29 +1116,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-10T16:41:02+00:00"
+            "time": "2026-07-08T15:56:20+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
-            "version": "v1.0.5",
+            "version": "v1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/uri-template.git",
-                "reference": "4f4bbd4e7172148801e76e3decc1e559bdee34e1"
+                "reference": "d7580af6d3f8384325d9cd3e99b21c3ed1848176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/4f4bbd4e7172148801e76e3decc1e559bdee34e1",
-                "reference": "4f4bbd4e7172148801e76e3decc1e559bdee34e1",
+                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/d7580af6d3f8384325d9cd3e99b21c3ed1848176",
+                "reference": "d7580af6d3f8384325d9cd3e99b21c3ed1848176",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
-                "symfony/polyfill-php80": "^1.24"
+                "symfony/polyfill-php80": "^1.25"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "uri-template/tests": "1.0.0"
             },
             "type": "library",
@@ -1096,7 +1186,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/uri-template/issues",
-                "source": "https://github.com/guzzle/uri-template/tree/v1.0.5"
+                "source": "https://github.com/guzzle/uri-template/tree/v1.0.9"
             },
             "funding": [
                 {
@@ -1112,20 +1202,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:27:06+00:00"
+            "time": "2026-07-08T16:19:22+00:00"
         },
         {
             "name": "laravel/framework",
-            "version": "v12.58.0",
+            "version": "v12.63.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "6172ae1f44ba5d89e111057ee4a4e7c27f5a610d"
+                "reference": "7adfddbf4738f2e6cae5419b0e6bc46d4cccfbcf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/6172ae1f44ba5d89e111057ee4a4e7c27f5a610d",
-                "reference": "6172ae1f44ba5d89e111057ee4a4e7c27f5a610d",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/7adfddbf4738f2e6cae5419b0e6bc46d4cccfbcf",
+                "reference": "7adfddbf4738f2e6cae5419b0e6bc46d4cccfbcf",
                 "shasum": ""
             },
             "require": {
@@ -1334,20 +1424,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-04-26T16:42:04+00:00"
+            "time": "2026-07-07T14:16:35+00:00"
         },
         {
             "name": "laravel/prompts",
-            "version": "v0.3.17",
+            "version": "v0.3.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/prompts.git",
-                "reference": "6a82ac19a28b916ae0885828795dbd4c59d9a818"
+                "reference": "7753c65c281c2550c7c183f14e18062073b7d821"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/prompts/zipball/6a82ac19a28b916ae0885828795dbd4c59d9a818",
-                "reference": "6a82ac19a28b916ae0885828795dbd4c59d9a818",
+                "url": "https://api.github.com/repos/laravel/prompts/zipball/7753c65c281c2550c7c183f14e18062073b7d821",
+                "reference": "7753c65c281c2550c7c183f14e18062073b7d821",
                 "shasum": ""
             },
             "require": {
@@ -1391,9 +1481,9 @@
             "description": "Add beautiful and user-friendly forms to your command-line applications.",
             "support": {
                 "issues": "https://github.com/laravel/prompts/issues",
-                "source": "https://github.com/laravel/prompts/tree/v0.3.17"
+                "source": "https://github.com/laravel/prompts/tree/v0.3.21"
             },
-            "time": "2026-04-20T16:07:33+00:00"
+            "time": "2026-06-26T00:11:25+00:00"
         },
         {
             "name": "laravel/serializable-closure",
@@ -1647,16 +1737,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "3.33.0",
+            "version": "3.35.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "570b8871e0ce693764434b29154c54b434905350"
+                "reference": "b277b5dc3d56650b68904117124e79c851e12376"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/570b8871e0ce693764434b29154c54b434905350",
-                "reference": "570b8871e0ce693764434b29154c54b434905350",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/b277b5dc3d56650b68904117124e79c851e12376",
+                "reference": "b277b5dc3d56650b68904117124e79c851e12376",
                 "shasum": ""
             },
             "require": {
@@ -1724,9 +1814,9 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/3.33.0"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.35.2"
             },
-            "time": "2026-03-25T07:59:30+00:00"
+            "time": "2026-07-06T14:42:07+00:00"
         },
         {
             "name": "league/flysystem-local",
@@ -1779,16 +1869,16 @@
         },
         {
             "name": "league/mime-type-detection",
-            "version": "1.16.0",
+            "version": "1.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/mime-type-detection.git",
-                "reference": "2d6702ff215bf922936ccc1ad31007edc76451b9"
+                "reference": "f5f47eff7c48ed1003069a2ca67f316fb4021c76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/2d6702ff215bf922936ccc1ad31007edc76451b9",
-                "reference": "2d6702ff215bf922936ccc1ad31007edc76451b9",
+                "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/f5f47eff7c48ed1003069a2ca67f316fb4021c76",
+                "reference": "f5f47eff7c48ed1003069a2ca67f316fb4021c76",
                 "shasum": ""
             },
             "require": {
@@ -1798,7 +1888,7 @@
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^3.2",
                 "phpstan/phpstan": "^0.12.68",
-                "phpunit/phpunit": "^8.5.8 || ^9.3 || ^10.0"
+                "phpunit/phpunit": "^8.5.8 || ^9.3 || ^10.0 || ^11.0 || ^12.0"
             },
             "type": "library",
             "autoload": {
@@ -1819,7 +1909,7 @@
             "description": "Mime-type detection for Flysystem",
             "support": {
                 "issues": "https://github.com/thephpleague/mime-type-detection/issues",
-                "source": "https://github.com/thephpleague/mime-type-detection/tree/1.16.0"
+                "source": "https://github.com/thephpleague/mime-type-detection/tree/1.17.0"
             },
             "funding": [
                 {
@@ -1831,7 +1921,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-21T08:32:55+00:00"
+            "time": "2026-07-09T11:49:27+00:00"
         },
         {
             "name": "league/uri",
@@ -2120,16 +2210,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "3.11.4",
+            "version": "3.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPHP/carbon.git",
-                "reference": "e890471a3494740f7d9326d72ce6a8c559ffee60"
+                "reference": "2937ad3d1d2c506fd2bc97d571438a95641f44e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/e890471a3494740f7d9326d72ce6a8c559ffee60",
-                "reference": "e890471a3494740f7d9326d72ce6a8c559ffee60",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/2937ad3d1d2c506fd2bc97d571438a95641f44e2",
+                "reference": "2937ad3d1d2c506fd2bc97d571438a95641f44e2",
                 "shasum": ""
             },
             "require": {
@@ -2221,7 +2311,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-07T09:57:54+00:00"
+            "time": "2026-07-09T18:23:49+00:00"
         },
         {
             "name": "nette/schema",
@@ -2292,16 +2382,16 @@
         },
         {
             "name": "nette/utils",
-            "version": "v4.1.3",
+            "version": "v4.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe"
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/bb3ea637e3d131d72acc033cfc2746ee893349fe",
-                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe",
+                "url": "https://api.github.com/repos/nette/utils/zipball/7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
                 "shasum": ""
             },
             "require": {
@@ -2377,9 +2467,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.1.3"
+                "source": "https://github.com/nette/utils/tree/v4.1.4"
             },
-            "time": "2026-02-13T03:05:33+00:00"
+            "time": "2026-05-11T20:49:54+00:00"
         },
         {
             "name": "nunomaduro/termwind",
@@ -3077,20 +3167,20 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "4.9.2",
+            "version": "4.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "8429c78ca35a09f27565311b98101e2826affde0"
+                "reference": "1df15849d00943a67d677dc9cfd80795f038c9f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/8429c78ca35a09f27565311b98101e2826affde0",
-                "reference": "8429c78ca35a09f27565311b98101e2826affde0",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/1df15849d00943a67d677dc9cfd80795f038c9f8",
+                "reference": "1df15849d00943a67d677dc9cfd80795f038c9f8",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.8.16 || ^0.9 || ^0.10 || ^0.11 || ^0.12 || ^0.13 || ^0.14",
+                "brick/math": ">=0.8.16 <=0.18",
                 "php": "^8.0",
                 "ramsey/collection": "^1.2 || ^2.0"
             },
@@ -3149,28 +3239,27 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/uuid/issues",
-                "source": "https://github.com/ramsey/uuid/tree/4.9.2"
+                "source": "https://github.com/ramsey/uuid/tree/4.9.3"
             },
-            "time": "2025-12-14T04:43:48+00:00"
+            "time": "2026-06-18T03:57:49+00:00"
         },
         {
             "name": "symfony/clock",
-            "version": "v7.4.8",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/clock.git",
-                "reference": "674fa3b98e21531dd040e613479f5f6fa8f32111"
+                "reference": "701ef4de9705d6c32292ebee5e8044094a09fbf6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/clock/zipball/674fa3b98e21531dd040e613479f5f6fa8f32111",
-                "reference": "674fa3b98e21531dd040e613479f5f6fa8f32111",
+                "url": "https://api.github.com/repos/symfony/clock/zipball/701ef4de9705d6c32292ebee5e8044094a09fbf6",
+                "reference": "701ef4de9705d6c32292ebee5e8044094a09fbf6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "psr/clock": "^1.0",
-                "symfony/polyfill-php83": "^1.28"
+                "php": ">=8.4.1",
+                "psr/clock": "^1.0"
             },
             "provide": {
                 "psr/clock-implementation": "1.0"
@@ -3209,7 +3298,7 @@
                 "time"
             ],
             "support": {
-                "source": "https://github.com/symfony/clock/tree/v7.4.8"
+                "source": "https://github.com/symfony/clock/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -3229,20 +3318,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.9",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "d7d2b64a45a89d607865927b176fa51c33ddbb58"
+                "reference": "92f58bc4bf97a92ed1b9f367f0cd44f20bde0e87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/d7d2b64a45a89d607865927b176fa51c33ddbb58",
-                "reference": "d7d2b64a45a89d607865927b176fa51c33ddbb58",
+                "url": "https://api.github.com/repos/symfony/console/zipball/92f58bc4bf97a92ed1b9f367f0cd44f20bde0e87",
+                "reference": "92f58bc4bf97a92ed1b9f367f0cd44f20bde0e87",
                 "shasum": ""
             },
             "require": {
@@ -3307,7 +3396,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.9"
+                "source": "https://github.com/symfony/console/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -3327,24 +3416,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-22T15:21:55+00:00"
+            "time": "2026-06-16T11:50:14+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v7.4.9",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "b75663ed96cf4756e28e3105476f220f92886cc4"
+                "reference": "dc0e2be45c9b5588c82414f02ac574b4b986abcd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/b75663ed96cf4756e28e3105476f220f92886cc4",
-                "reference": "b75663ed96cf4756e28e3105476f220f92886cc4",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/dc0e2be45c9b5588c82414f02ac574b4b986abcd",
+                "reference": "dc0e2be45c9b5588c82414f02ac574b4b986abcd",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4.1"
             },
             "type": "library",
             "autoload": {
@@ -3376,7 +3465,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v7.4.9"
+                "source": "https://github.com/symfony/css-selector/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -3396,20 +3485,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-18T13:18:21+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
                 "shasum": ""
             },
             "require": {
@@ -3447,7 +3536,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -3467,20 +3556,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-13T15:52:40+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/error-handler",
-            "version": "v7.4.8",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "8dd79d8af777ee6cba2fd4d98da6ffb839f3c0fa"
+                "reference": "4e1a093b481f323e6e326451f9760c3868430673"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/8dd79d8af777ee6cba2fd4d98da6ffb839f3c0fa",
-                "reference": "8dd79d8af777ee6cba2fd4d98da6ffb839f3c0fa",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/4e1a093b481f323e6e326451f9760c3868430673",
+                "reference": "4e1a093b481f323e6e326451f9760c3868430673",
                 "shasum": ""
             },
             "require": {
@@ -3529,7 +3618,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v7.4.8"
+                "source": "https://github.com/symfony/error-handler/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -3549,28 +3638,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-06-05T06:22:21+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.4.9",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "e4a2e29753c7801f7a8340e066cfa788f3bc8101"
+                "reference": "abd6c11dc468725d1627302ad10f6cd486e9e3d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/e4a2e29753c7801f7a8340e066cfa788f3bc8101",
-                "reference": "e4a2e29753c7801f7a8340e066cfa788f3bc8101",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/abd6c11dc468725d1627302ad10f6cd486e9e3d0",
+                "reference": "abd6c11dc468725d1627302ad10f6cd486e9e3d0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/event-dispatcher-contracts": "^2.5|^3"
             },
             "conflict": {
-                "symfony/dependency-injection": "<6.4",
+                "symfony/security-http": "<7.4",
                 "symfony/service-contracts": "<2.5"
             },
             "provide": {
@@ -3579,14 +3669,14 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/error-handler": "^6.4|^7.0|^8.0",
-                "symfony/expression-language": "^6.4|^7.0|^8.0",
-                "symfony/framework-bundle": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/error-handler": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/framework-bundle": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/stopwatch": "^6.4|^7.0|^8.0"
+                "symfony/stopwatch": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3614,7 +3704,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.9"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -3634,20 +3724,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-18T13:18:21+00:00"
+            "time": "2026-06-09T12:28:30+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32"
+                "reference": "c7de7a00ffb67842132da02ea92988a39ccd9f4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/ccba7060602b7fed0b03c85bf025257f76d9ef32",
-                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/c7de7a00ffb67842132da02ea92988a39ccd9f4e",
+                "reference": "c7de7a00ffb67842132da02ea92988a39ccd9f4e",
                 "shasum": ""
             },
             "require": {
@@ -3694,7 +3784,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -3714,20 +3804,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T13:30:16+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v7.4.8",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "e0be088d22278583a82da281886e8c3592fbf149"
+                "reference": "13b38720174286f55d1761152b575a8d1436fc25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/e0be088d22278583a82da281886e8c3592fbf149",
-                "reference": "e0be088d22278583a82da281886e8c3592fbf149",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/13b38720174286f55d1761152b575a8d1436fc25",
+                "reference": "13b38720174286f55d1761152b575a8d1436fc25",
                 "shasum": ""
             },
             "require": {
@@ -3762,7 +3852,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.4.8"
+                "source": "https://github.com/symfony/finder/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -3782,20 +3872,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-06-27T08:31:18+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.4.8",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "9381209597ec66c25be154cbf2289076e64d1eab"
+                "reference": "06db5ae1552177bf8572f8908839f12e3c06aed3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/9381209597ec66c25be154cbf2289076e64d1eab",
-                "reference": "9381209597ec66c25be154cbf2289076e64d1eab",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/06db5ae1552177bf8572f8908839f12e3c06aed3",
+                "reference": "06db5ae1552177bf8572f8908839f12e3c06aed3",
                 "shasum": ""
             },
             "require": {
@@ -3844,7 +3934,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.4.8"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -3864,20 +3954,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-06-11T07:31:44+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v7.4.10",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "23486f59234c6fd6e8f1bec97124f3829d686627"
+                "reference": "e99af79b1e776646eda0e1c23b7b45c184ff99be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/23486f59234c6fd6e8f1bec97124f3829d686627",
-                "reference": "23486f59234c6fd6e8f1bec97124f3829d686627",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/e99af79b1e776646eda0e1c23b7b45c184ff99be",
+                "reference": "e99af79b1e776646eda0e1c23b7b45c184ff99be",
                 "shasum": ""
             },
             "require": {
@@ -3963,7 +4053,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.4.10"
+                "source": "https://github.com/symfony/http-kernel/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -3983,20 +4073,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-06T12:07:34+00:00"
+            "time": "2026-06-27T09:14:35+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v7.4.8",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "f6ea532250b476bfc1b56699b388a1bdbf168f62"
+                "reference": "f88ce03ae73e3edb5c176ce1f337709996e88495"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/f6ea532250b476bfc1b56699b388a1bdbf168f62",
-                "reference": "f6ea532250b476bfc1b56699b388a1bdbf168f62",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/f88ce03ae73e3edb5c176ce1f337709996e88495",
+                "reference": "f88ce03ae73e3edb5c176ce1f337709996e88495",
                 "shasum": ""
             },
             "require": {
@@ -4047,7 +4137,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v7.4.8"
+                "source": "https://github.com/symfony/mailer/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -4067,20 +4157,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-06-13T08:51:35+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v7.4.9",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "2d550c4758ba4c47519a6667c36553d535705b0c"
+                "reference": "a845722765c4f6b2ce88beaf4f4479975b186770"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/2d550c4758ba4c47519a6667c36553d535705b0c",
-                "reference": "2d550c4758ba4c47519a6667c36553d535705b0c",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/a845722765c4f6b2ce88beaf4f4479975b186770",
+                "reference": "a845722765c4f6b2ce88beaf4f4479975b186770",
                 "shasum": ""
             },
             "require": {
@@ -4136,7 +4226,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v7.4.9"
+                "source": "https://github.com/symfony/mime/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -4156,7 +4246,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-29T13:21:53+00:00"
+            "time": "2026-05-23T16:22:37+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4243,16 +4333,16 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e"
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/4864388bfbd3001ce88e234fab652acd91fdc57e",
-                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/e9247d281d694a5120554d9afaf54e070e88a603",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603",
                 "shasum": ""
             },
             "require": {
@@ -4301,7 +4391,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -4321,20 +4411,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-26T13:13:48+00:00"
+            "time": "2026-05-26T05:58:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3"
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/9614ac4d8061dc257ecc64cba1b140873dce8ad3",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/dc21118016c039a66235cf93d96b435ffb282412",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412",
                 "shasum": ""
             },
             "require": {
@@ -4388,7 +4478,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -4408,20 +4498,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-10T14:38:51+00:00"
+            "time": "2026-05-25T15:22:23+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.37.0",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
                 "shasum": ""
             },
             "require": {
@@ -4473,7 +4563,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -4493,20 +4583,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-25T13:48:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.37.0",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
-                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -4558,7 +4648,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -4578,7 +4668,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T17:25:58+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
@@ -4666,16 +4756,16 @@
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.37.0",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "3600c2cb22399e25bb226e4a135ce91eeb2a6149"
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/3600c2cb22399e25bb226e4a135ce91eeb2a6149",
-                "reference": "3600c2cb22399e25bb226e4a135ce91eeb2a6149",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/796a26abb75ce49f3a84433cd81bf1009d73d5f8",
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8",
                 "shasum": ""
             },
             "require": {
@@ -4722,7 +4812,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -4742,20 +4832,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T17:25:58+00:00"
+            "time": "2026-05-27T06:51:48+00:00"
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
-                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06"
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/88486db2c389b290bf87ff1de7ebc1e13e42bb06",
-                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
                 "shasum": ""
             },
             "require": {
@@ -4802,7 +4892,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -4822,20 +4912,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T18:47:49+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/polyfill-php85",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php85.git",
-                "reference": "fcfa4973a9917cef23f2e38774da74a2b7d115ee"
+                "reference": "ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/fcfa4973a9917cef23f2e38774da74a2b7d115ee",
-                "reference": "fcfa4973a9917cef23f2e38774da74a2b7d115ee",
+                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1",
+                "reference": "ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1",
                 "shasum": ""
             },
             "require": {
@@ -4882,7 +4972,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php85/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php85/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -4902,7 +4992,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-26T13:10:57+00:00"
+            "time": "2026-05-26T02:25:22+00:00"
         },
         {
             "name": "symfony/polyfill-uuid",
@@ -4989,16 +5079,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.4.8",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a"
+                "reference": "f5804be144caceb570f6747519999636b664f24c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/60f19cd3badc8de688421e21e4305eba50f8089a",
-                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a",
+                "url": "https://api.github.com/repos/symfony/process/zipball/f5804be144caceb570f6747519999636b664f24c",
+                "reference": "f5804be144caceb570f6747519999636b664f24c",
                 "shasum": ""
             },
             "require": {
@@ -5030,7 +5120,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.8"
+                "source": "https://github.com/symfony/process/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -5050,20 +5140,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-05-23T16:05:06+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v7.4.9",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "287771d8bc86eacb30678dd10eda6c64a859951f"
+                "reference": "3a162171bb008e5e0f15dce6581373a4c0e8390d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/287771d8bc86eacb30678dd10eda6c64a859951f",
-                "reference": "287771d8bc86eacb30678dd10eda6c64a859951f",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/3a162171bb008e5e0f15dce6581373a4c0e8390d",
+                "reference": "3a162171bb008e5e0f15dce6581373a4c0e8390d",
                 "shasum": ""
             },
             "require": {
@@ -5115,7 +5205,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v7.4.9"
+                "source": "https://github.com/symfony/routing/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -5135,20 +5225,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-22T15:21:55+00:00"
+            "time": "2026-05-24T11:20:33+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
-                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0",
                 "shasum": ""
             },
             "require": {
@@ -5202,7 +5292,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -5222,39 +5312,38 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-28T09:44:51+00:00"
+            "time": "2026-06-16T09:55:08+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v7.4.8",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "114ac57257d75df748eda23dd003878080b8e688"
+                "reference": "afd5944f4005862d961efb85c8bbd5c523c4e3c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/114ac57257d75df748eda23dd003878080b8e688",
-                "reference": "114ac57257d75df748eda23dd003878080b8e688",
+                "url": "https://api.github.com/repos/symfony/string/zipball/afd5944f4005862d961efb85c8bbd5c523c4e3c9",
+                "reference": "afd5944f4005862d961efb85c8bbd5c523c4e3c9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3.0",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-intl-grapheme": "~1.33",
-                "symfony/polyfill-intl-normalizer": "~1.0",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": ">=8.4.1",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-intl-grapheme": "^1.33",
+                "symfony/polyfill-intl-normalizer": "^1.0",
+                "symfony/polyfill-mbstring": "^1.0"
             },
             "conflict": {
                 "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/emoji": "^7.1|^8.0",
-                "symfony/http-client": "^6.4|^7.0|^8.0",
-                "symfony/intl": "^6.4|^7.0|^8.0",
+                "symfony/emoji": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/intl": "^7.4|^8.0",
                 "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^6.4|^7.0|^8.0"
+                "symfony/var-exporter": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -5293,7 +5382,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.4.8"
+                "source": "https://github.com/symfony/string/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -5313,38 +5402,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v7.4.10",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "ada7578c30dd5feaa8259cff3e885069ea81ddde"
+                "reference": "342b4218630dc2cf284cedcb2080c80b13404014"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/ada7578c30dd5feaa8259cff3e885069ea81ddde",
-                "reference": "ada7578c30dd5feaa8259cff3e885069ea81ddde",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/342b4218630dc2cf284cedcb2080c80b13404014",
+                "reference": "342b4218630dc2cf284cedcb2080c80b13404014",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/translation-contracts": "^2.5.3|^3.3"
+                "php": ">=8.4.1",
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/translation-contracts": "^3.6.1"
             },
             "conflict": {
                 "nikic/php-parser": "<5.0",
-                "symfony/config": "<6.4",
-                "symfony/console": "<6.4",
-                "symfony/dependency-injection": "<6.4",
                 "symfony/http-client-contracts": "<2.5",
-                "symfony/http-kernel": "<6.4",
-                "symfony/service-contracts": "<2.5",
-                "symfony/twig-bundle": "<6.4",
-                "symfony/yaml": "<6.4"
+                "symfony/service-contracts": "<2.5"
             },
             "provide": {
                 "symfony/translation-implementation": "2.3|3.0"
@@ -5352,17 +5434,17 @@
             "require-dev": {
                 "nikic/php-parser": "^5.0",
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/console": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/finder": "^6.4|^7.0|^8.0",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/console": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/finder": "^7.4|^8.0",
                 "symfony/http-client-contracts": "^2.5|^3.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/intl": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/intl": "^7.4|^8.0",
                 "symfony/polyfill-intl-icu": "^1.21",
-                "symfony/routing": "^6.4|^7.0|^8.0",
+                "symfony/routing": "^7.4|^8.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/yaml": "^6.4|^7.0|^8.0"
+                "symfony/yaml": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -5393,7 +5475,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v7.4.10"
+                "source": "https://github.com/symfony/translation/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -5413,20 +5495,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-06T11:19:24+00:00"
+            "time": "2026-06-06T11:11:44+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d"
+                "reference": "ccb206b98faccc511ebae8e5fad50f2dc0b30621"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/0ab302977a952b42fd51475c4ebac81f8da0a95d",
-                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/ccb206b98faccc511ebae8e5fad50f2dc0b30621",
+                "reference": "ccb206b98faccc511ebae8e5fad50f2dc0b30621",
                 "shasum": ""
             },
             "require": {
@@ -5475,7 +5557,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -5495,7 +5577,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T13:30:16+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/uid",
@@ -5577,16 +5659,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.4.8",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "9510c3966f749a1d1ff0059e1eabef6cc621e7fd"
+                "reference": "9a3a56a4a1e65a5cb4f8d13801fe8ab0a170e358"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/9510c3966f749a1d1ff0059e1eabef6cc621e7fd",
-                "reference": "9510c3966f749a1d1ff0059e1eabef6cc621e7fd",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/9a3a56a4a1e65a5cb4f8d13801fe8ab0a170e358",
+                "reference": "9a3a56a4a1e65a5cb4f8d13801fe8ab0a170e358",
                 "shasum": ""
             },
             "require": {
@@ -5640,7 +5722,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.4.8"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -5660,7 +5742,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T13:44:50+00:00"
+            "time": "2026-06-08T20:24:16+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -5719,16 +5801,16 @@
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "v5.6.3",
+            "version": "v5.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "955e7815d677a3eaa7075231212f2110983adecc"
+                "reference": "416df702837983f8d5ff48c9c3fee4f5f57b980b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/955e7815d677a3eaa7075231212f2110983adecc",
-                "reference": "955e7815d677a3eaa7075231212f2110983adecc",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/416df702837983f8d5ff48c9c3fee4f5f57b980b",
+                "reference": "416df702837983f8d5ff48c9c3fee4f5f57b980b",
                 "shasum": ""
             },
             "require": {
@@ -5787,7 +5869,7 @@
             ],
             "support": {
                 "issues": "https://github.com/vlucas/phpdotenv/issues",
-                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.3"
+                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.4"
             },
             "funding": [
                 {
@@ -5799,7 +5881,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-27T19:49:13+00:00"
+            "time": "2026-07-06T19:11:50+00:00"
         },
         {
             "name": "voku/portable-ascii",
@@ -5877,6 +5959,78 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "artisanpack-ui/ai",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ArtisanPack-UI/ai.git",
+                "reference": "082f1cd337742d34b8035d116c6c5ad8e5453fca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/ai/zipball/082f1cd337742d34b8035d116c6c5ad8e5453fca",
+                "reference": "082f1cd337742d34b8035d116c6c5ad8e5453fca",
+                "shasum": ""
+            },
+            "require": {
+                "artisanpack-ui/core": "^1.0",
+                "illuminate/support": "^12.0|^13.0",
+                "laravel/ai": "^0.8",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "artisanpack-ui/code-style": "^1.1",
+                "artisanpack-ui/code-style-pint": "^1.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "friendsofphp/php-cs-fixer": "^3.75",
+                "laravel/pint": "^1.26",
+                "livewire/livewire": "^3.6",
+                "orchestra/testbench": "^10.2|^11.0",
+                "pestphp/pest": "^3.8|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.2|^4.1"
+            },
+            "suggest": {
+                "artisanpack-ui/cms-framework": "Automatically registers AI credentials, features, budget and cache setting groups under the CMS admin surface.",
+                "artisanpack-ui/livewire-ui-components": "Renders the AI Settings and Usage admin surfaces using x-artisanpack-* components.",
+                "livewire/livewire": "Required to mount the AI Settings and Usage dashboard Livewire components under cms-framework's admin nav."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Ai": "ArtisanPackUI\\Ai\\Facades\\Ai"
+                    },
+                    "providers": [
+                        "ArtisanPackUI\\Ai\\AiServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "ArtisanPackUI\\Ai\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jacob Martella",
+                    "email": "me@jacobmartella.com"
+                }
+            ],
+            "description": "Shared AI foundation for the ArtisanPack UI ecosystem, built on top of laravel/ai.",
+            "support": {
+                "issues": "https://github.com/ArtisanPack-UI/ai/issues",
+                "source": "https://github.com/ArtisanPack-UI/ai/tree/v1.0.0"
+            },
+            "time": "2026-07-06T21:25:38+00:00"
+        },
         {
             "name": "artisanpack-ui/code-style",
             "version": "1.1.0",
@@ -5992,6 +6146,157 @@
                 "source": "https://github.com/ArtisanPack-UI/code-style-pint/tree/v1.1.0"
             },
             "time": "2025-11-23T21:13:56+00:00"
+        },
+        {
+            "name": "aws/aws-crt-php",
+            "version": "v1.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/awslabs/aws-crt-php.git",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/awslabs/aws-crt-php/zipball/d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35||^5.6.3||^9.5",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "suggest": {
+                "ext-awscrt": "Make sure you install awscrt native extension to use any of the functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "AWS SDK Common Runtime Team",
+                    "email": "aws-sdk-common-runtime@amazon.com"
+                }
+            ],
+            "description": "AWS Common Runtime for PHP",
+            "homepage": "https://github.com/awslabs/aws-crt-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "crt",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/awslabs/aws-crt-php/issues",
+                "source": "https://github.com/awslabs/aws-crt-php/tree/v1.2.7"
+            },
+            "time": "2024-10-18T22:15:13+00:00"
+        },
+        {
+            "name": "aws/aws-sdk-php",
+            "version": "3.388.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aws/aws-sdk-php.git",
+                "reference": "dc03d7967241af550214ba210d238482fbafb24d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/dc03d7967241af550214ba210d238482fbafb24d",
+                "reference": "dc03d7967241af550214ba210d238482fbafb24d",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-crt-php": "^1.2.3",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/promises": "^2.0",
+                "guzzlehttp/psr7": "^2.4.5",
+                "mtdowling/jmespath.php": "^2.9.1",
+                "php": ">=8.1",
+                "psr/http-message": "^1.0 || ^2.0",
+                "symfony/filesystem": "^v5.4.45 || ^v6.4.3 || ^v7.1.0 || ^v8.0.0"
+            },
+            "require-dev": {
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "composer/composer": "^2.7.8",
+                "dms/phpunit-arraysubset-asserts": "^v0.5.0",
+                "doctrine/cache": "~1.4",
+                "ext-dom": "*",
+                "ext-openssl": "*",
+                "ext-sockets": "*",
+                "phpunit/phpunit": "^10.0",
+                "psr/cache": "^2.0 || ^3.0",
+                "psr/simple-cache": "^2.0 || ^3.0",
+                "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
+                "yoast/phpunit-polyfills": "^2.0"
+            },
+            "suggest": {
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
+                "ext-curl": "To send requests using cURL",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
+                "ext-pcntl": "To use client-side monitoring",
+                "ext-sockets": "To use client-side monitoring"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Aws\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/data/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Amazon Web Services",
+                    "homepage": "https://aws.amazon.com"
+                }
+            ],
+            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
+            "homepage": "https://aws.amazon.com/sdk-for-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "cloud",
+                "dynamodb",
+                "ec2",
+                "glacier",
+                "s3",
+                "sdk"
+            ],
+            "support": {
+                "forum": "https://github.com/aws/aws-sdk-php/discussions",
+                "issues": "https://github.com/aws/aws-sdk-php/issues",
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.388.3"
+            },
+            "time": "2026-07-09T18:07:47+00:00"
         },
         {
             "name": "brianium/paratest",
@@ -6228,83 +6533,6 @@
                 }
             ],
             "time": "2024-11-12T16:29:46+00:00"
-        },
-        {
-            "name": "composer/semver",
-            "version": "3.4.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/semver.git",
-                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
-                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.2 || ^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^1.11",
-                "symfony/phpunit-bridge": "^3 || ^7"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\Semver\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nils Adermann",
-                    "email": "naderman@naderman.de",
-                    "homepage": "http://www.naderman.de"
-                },
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                },
-                {
-                    "name": "Rob Bast",
-                    "email": "rob.bast@gmail.com",
-                    "homepage": "http://robbast.nl"
-                }
-            ],
-            "description": "Semver library that offers utilities, version constraint parsing and validation.",
-            "keywords": [
-                "semantic",
-                "semver",
-                "validation",
-                "versioning"
-            ],
-            "support": {
-                "irc": "ircs://irc.libera.chat:6697/composer",
-                "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.4.4"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-08-20T19:15:30+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -7044,6 +7272,80 @@
             "time": "2025-03-19T14:43:43+00:00"
         },
         {
+            "name": "laravel/ai",
+            "version": "v0.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/ai.git",
+                "reference": "b23bc857576d7c4b3bb52ffd8be936ae74005d23"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/ai/zipball/b23bc857576d7c4b3bb52ffd8be936ae74005d23",
+                "reference": "b23bc857576d7c4b3bb52ffd8be936ae74005d23",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-sdk-php": "^3.339",
+                "illuminate/console": "^12.0|^13.0",
+                "illuminate/container": "^12.0|^13.0",
+                "illuminate/contracts": "^12.0|^13.0",
+                "illuminate/database": "^12.0|^13.0",
+                "illuminate/filesystem": "^12.0|^13.0",
+                "illuminate/json-schema": "^12.62|^13.15",
+                "illuminate/support": "^12.0|^13.0",
+                "laravel/prompts": "^0.3.6",
+                "laravel/serializable-closure": "^2.0",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "laravel/mcp": "^0.8",
+                "laravel/pint": "^1.26",
+                "mockery/mockery": "^1.6.12",
+                "orchestra/testbench": "^10.6|^11.0",
+                "pestphp/pest": "^3.0|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.0|^4.0",
+                "phpstan/phpstan": "^2.1"
+            },
+            "suggest": {
+                "laravel/mcp": "Required to use MCP client tools or MCP server tools with Laravel AI agents."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Ai\\AiServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "functions.php"
+                ],
+                "psr-4": {
+                    "Laravel\\Ai\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The official AI SDK for Laravel.",
+            "homepage": "https://github.com/laravel/ai",
+            "keywords": [
+                "ai",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/ai/issues",
+                "source": "https://github.com/laravel/ai"
+            },
+            "time": "2026-06-10T11:23:35+00:00"
+        },
+        {
             "name": "laravel/pail",
             "version": "v1.2.6",
             "source": {
@@ -7258,6 +7560,82 @@
             "time": "2026-02-06T14:12:35+00:00"
         },
         {
+            "name": "livewire/livewire",
+            "version": "v3.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/livewire/livewire.git",
+                "reference": "e77fce60d0615d68dc6b8fafe98a6739d9752a24"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/livewire/livewire/zipball/e77fce60d0615d68dc6b8fafe98a6739d9752a24",
+                "reference": "e77fce60d0615d68dc6b8fafe98a6739d9752a24",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/routing": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/validation": "^10.0|^11.0|^12.0|^13.0",
+                "laravel/prompts": "^0.1.24|^0.2|^0.3",
+                "league/mime-type-detection": "^1.9",
+                "php": "^8.1",
+                "symfony/console": "^6.0|^7.0|^8.0",
+                "symfony/http-kernel": "^6.2|^7.0|^8.0"
+            },
+            "require-dev": {
+                "calebporzio/sushi": "^2.1",
+                "laravel/framework": "^10.15.0|^11.0|^12.0|^13.0",
+                "mockery/mockery": "^1.3.1",
+                "orchestra/testbench": "^8.21.0|^9.0|^10.0|^11.0",
+                "orchestra/testbench-dusk": "^8.24|^9.1|^10.0|^11.0",
+                "phpunit/phpunit": "^10.4|^11.5|^12.5",
+                "psy/psysh": "^0.11.22|^0.12"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Livewire": "Livewire\\Livewire"
+                    },
+                    "providers": [
+                        "Livewire\\LivewireServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Livewire\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Caleb Porzio",
+                    "email": "calebporzio@gmail.com"
+                }
+            ],
+            "description": "A front-end framework for Laravel.",
+            "support": {
+                "issues": "https://github.com/livewire/livewire/issues",
+                "source": "https://github.com/livewire/livewire/tree/v3.8.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/livewire",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-27T03:14:20+00:00"
+        },
+        {
             "name": "mockery/mockery",
             "version": "1.6.12",
             "source": {
@@ -7339,6 +7717,72 @@
                 "source": "https://github.com/mockery/mockery"
             },
             "time": "2024-05-16T03:13:13+00:00"
+        },
+        {
+            "name": "mtdowling/jmespath.php",
+            "version": "2.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jmespath/jmespath.php.git",
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.17"
+            },
+            "require-dev": {
+                "composer/xdebug-handler": "^3.0.3",
+                "phpunit/phpunit": "^8.5.52"
+            },
+            "bin": [
+                "bin/jp.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.9-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/JmesPath.php"
+                ],
+                "psr-4": {
+                    "JmesPath\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Declaratively specify how to extract elements from a JSON document",
+            "keywords": [
+                "json",
+                "jsonpath"
+            ],
+            "support": {
+                "issues": "https://github.com/jmespath/jmespath.php/issues",
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.9.2"
+            },
+            "time": "2026-07-06T18:56:19+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -8667,16 +9111,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "2.3.2",
+            "version": "2.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
-                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
                 "shasum": ""
             },
             "require": {
@@ -8708,9 +9152,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.3"
             },
-            "time": "2026-01-25T14:56:51+00:00"
+            "time": "2026-07-08T07:01:06+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -10892,25 +11336,26 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.4.9",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "dcd8f96bcdc0f128ec406c765cc066c6035d1be3"
+                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/dcd8f96bcdc0f128ec406c765cc066c6035d1be3",
-                "reference": "dcd8f96bcdc0f128ec406c765cc066c6035d1be3",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/99aec13b82b4967ec5088222c4a3ecca955949c2",
+                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.8"
             },
             "require-dev": {
-                "symfony/process": "^6.4|^7.0|^8.0"
+                "symfony/process": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -10938,7 +11383,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.4.9"
+                "source": "https://github.com/symfony/filesystem/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -10958,7 +11403,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-18T13:18:21+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/options-resolver",
@@ -11033,16 +11478,16 @@
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.37.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c"
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c",
-                "reference": "4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
                 "shasum": ""
             },
             "require": {
@@ -11089,7 +11534,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.37.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -11109,7 +11554,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-26T12:45:58+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -11364,16 +11809,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "2.3.0",
+            "version": "2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "eb0d790f735ba6cff25c683a85a1da0eadeff9e4"
+                "reference": "2ccb7c2e821038c03a3e6e1700c570c158c55f70"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/eb0d790f735ba6cff25c683a85a1da0eadeff9e4",
-                "reference": "eb0d790f735ba6cff25c683a85a1da0eadeff9e4",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/2ccb7c2e821038c03a3e6e1700c570c158c55f70",
+                "reference": "2ccb7c2e821038c03a3e6e1700c570c158c55f70",
                 "shasum": ""
             },
             "require": {
@@ -11389,7 +11834,11 @@
             },
             "type": "library",
             "extra": {
+                "psalm": {
+                    "pluginClass": "Webmozart\\Assert\\PsalmPlugin"
+                },
                 "branch-alias": {
+                    "dev-master": "2.0-dev",
                     "dev-feature/2-0": "2.0-dev"
                 }
             },
@@ -11420,9 +11869,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/2.3.0"
+                "source": "https://github.com/webmozarts/assert/tree/2.4.1"
             },
-            "time": "2026-04-11T10:33:05+00:00"
+            "time": "2026-06-15T15:31:57+00:00"
         }
     ],
     "aliases": [],
@@ -11434,8 +11883,5 @@
         "php": "^8.2"
     },
     "platform-dev": {},
-    "platform-overrides": {
-        "php": "8.2"
-    },
     "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b9ac6c50977ee2239b3f6c8ba50f8806",
+    "content-hash": "ac738dd4c9c843e85284b52722e48649",
     "packages": [
         {
             "name": "artisanpack-ui/core",
@@ -11880,7 +11880,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.2"
+        "php": "^8.3"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/config/artisanpack/compliance.php
+++ b/config/artisanpack/compliance.php
@@ -157,6 +157,15 @@ return [
             'sex_life_orientation',
         ],
 
+        // AI-agent surfaces (privacy-policy draft, DPIA assistance, consent
+        // text). Requires artisanpack-ui/ai to be installed. The guard is
+        // used on the /api/v1/compliance/ai/* REST routes — defaults to
+        // 'sanctum' but consumer apps that don't ship Sanctum can override
+        // via COMPLIANCE_AI_GUARD (e.g. 'web' for session auth).
+        'ai' => [
+            'guard' => env('COMPLIANCE_AI_GUARD', 'sanctum'),
+        ],
+
         // Legal Bases (GDPR Article 6)
         'legal_bases' => [
             'consent' => 'Consent (Art. 6(1)(a))',

--- a/database/migrations/2025_01_01_100019_create_compliance_ai_drafts_table.php
+++ b/database/migrations/2025_01_01_100019_create_compliance_ai_drafts_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create( 'compliance_ai_drafts', function ( Blueprint $table ): void {
+            $table->id();
+            $table->string( 'feature_key', 128 )->index();
+            $table->string( 'subject_key', 191 )->nullable()->index();
+            $table->json( 'content' );
+            $table->json( 'metadata' )->nullable();
+            $table->unsignedBigInteger( 'created_by' )->nullable()->index();
+            $table->timestamp( 'created_at' )->useCurrent();
+        } );
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists( 'compliance_ai_drafts' );
+    }
+};

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -220,3 +220,66 @@ Gate::define( 'viewComplianceDashboard', fn ( $user ) => $user->hasRole( 'compli
 ```
 
 When pairing with `artisanpack-ui/rbac`, the Gate integration ensures `viewComplianceDashboard` resolves against an RBAC permission of the same slug if one exists.
+
+## AI features
+
+*Added in 1.1.0. Requires [`artisanpack-ui/ai`](https://github.com/ArtisanPack-UI/ai). See [Usage → AI features](usage.md#ai-features) for the surface reference; this section covers customization.*
+
+### Authorize draft persistence
+
+Draft writes go through a `manageComplianceAiDrafts` Gate. The package registers a default-deny stub — you must override it before any user can save. In your `AuthServiceProvider`:
+
+```php
+Gate::define( 'manageComplianceAiDrafts', function ( $user ) {
+    return $user->hasAnyRole( [ 'compliance-officer', 'dpo' ] );
+} );
+```
+
+### Change the REST guard
+
+The `/api/v1/compliance/ai/*` routes read the guard from `artisanpack.compliance.ai.guard` (default `sanctum`). For a Livewire-only app that doesn't ship Sanctum:
+
+```php
+// config/artisanpack/compliance.php
+'ai' => [
+    'guard' => env( 'COMPLIANCE_AI_GUARD', 'web' ),
+],
+```
+
+### Customize the AI feature registry
+
+The three compliance agents are auto-discovered by `artisanpack-ui/ai`'s `FeatureRegistry` from `ComplianceServiceProvider::aiFeatures()`. You can toggle them at runtime through the registry:
+
+```php
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+
+app( FeatureRegistry::class )->disable( 'compliance.privacy_policy_draft' );
+```
+
+Or via config in `config/artisanpack/ai.php`:
+
+```php
+'features' => [
+    'compliance.privacy_policy_draft' => [ 'enabled' => true, 'model' => 'claude-sonnet-4-6' ],
+],
+```
+
+The `model` override is useful for smoke-testing without paying Opus rates.
+
+### Draft retention
+
+`AiDraft` rows are append-only at the ORM layer — this is intentional so version history is preserved for legal review. If your organization needs a formal retention window for AI-generated drafts, add a scheduled job that runs `AiDraft::where('created_at', '<', now()->subMonths(24))->delete()` and logs to your audit trail. Hard-delete is the only path in `1.1.0`; there is no `SoftDeletes` column.
+
+### Consuming events on the browser
+
+The Livewire component dispatches five event categories per feature:
+
+- `compliance-ai:{featureKey}:success` — with `output` payload
+- `compliance-ai:{featureKey}:disabled` — feature toggled off
+- `compliance-ai:{featureKey}:missing-credentials` — provider credentials not set
+- `compliance-ai:{featureKey}:invalid-input` — agent rejected the payload (validation)
+- `compliance-ai:{featureKey}:error` — unexpected error
+
+Save-draft events are dispatched under the fixed names `compliance-ai:save-draft:success`, `compliance-ai:save-draft:rejected`, and `compliance-ai:save-draft:error` — the rejected event carries a `message` field naming which guard failed (unknown feature, gate deny, toggle off, missing acknowledgement).
+
+Prefer the JS `Livewire.on()` subscription over inline `x-on:` — event names contain `.` (from the feature key) which Alpine parses as directive modifiers.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -31,3 +31,33 @@ On the storage disk configured in `config/artisanpack/compliance.php`. The defau
 ## Does the package handle SCC / DPA paperwork?
 
 No — it tracks `ProcessingActivity` records (Article 30 RoPA), which is the precursor / index. It does not generate SCCs or DPA contracts.
+
+## Do I have to install `artisanpack-ui/ai` to use the compliance package?
+
+*Added in 1.1.0.*
+
+No. The AI package is a soft dependency — the compliance package boots and works fully without it. When the AI package is absent, the AI Livewire component and the `/api/v1/compliance/ai/*` REST endpoints simply stay unregistered.
+
+## Is AI-generated output from the agents legal advice?
+
+No. Every high-stakes agent (`PrivacyPolicyDraftAgent`, `DpiaAssistanceAgent`, `ConsentTextSuggestionAgent`) forces `requires_legal_review: true` on its output and includes a `review_checklist` naming things a lawyer must confirm. The host UI is required to render an un-dismissable "requires legal review" banner and gate viewing the draft body behind an acknowledgement checkbox. The package deliberately makes it hard to ship AI output as-is.
+
+## Can I stop a specific AI feature without uninstalling the package?
+
+*Added in 1.1.0.*
+
+Yes — toggle the feature off in the FeatureRegistry (`config/artisanpack/ai.php`):
+
+```php
+'features' => [
+    'compliance.privacy_policy_draft' => [ 'enabled' => false ],
+],
+```
+
+The agent will throw `FeatureDisabledException` when run, the REST endpoint returns 403, and `AiTools::saveDraft` rejects saves for that feature key. The `/features` endpoint reports the disabled state so front-ends can hide the affordance.
+
+## An AI-generated draft turned out wrong — can I delete or edit it?
+
+The `AiDraft` model is append-only at the ORM layer — any UPDATE throws a `RuntimeException`. This is deliberate: the version history is legal evidence. To "correct" a bad draft, save a new draft with the corrected content; both remain in the audit trail.
+
+If you need to hard-delete rows for a GDPR erasure cascade, use `AiDraft::query()->where(...)->delete()` and log the deletion event alongside the erasure trail. There is no soft-delete column in `1.1.0` — hard-delete is the only path.

--- a/docs/home.md
+++ b/docs/home.md
@@ -12,7 +12,7 @@ A Laravel package that wraps the GDPR / CCPA / LGPD compliance surface in a set 
 
 ## Architecture at a glance
 
-The package is organized into seven domains:
+The package is organized into eight domains:
 
 | Domain | Public entry | Persistence |
 |---|---|---|
@@ -23,6 +23,7 @@ The package is organized into seven domains:
 | Minimization | `DataMinimizerService` + Anonymization / Pseudonymization engines | (none — operates on app data) |
 | Retention | `PurgeExpiredData` command + `RetentionPolicy` / `CollectionPolicy` | `retention_policies`, `collection_policies` |
 | Monitoring + reporting | `ComplianceMonitor` + `ComplianceCheckInterface`; `ReportGenerator` + `ReportTypeInterface` | `compliance_check_results`, `compliance_violations`, `compliance_scores`, `scheduled_compliance_reports` |
+| AI (optional, since 1.1.0) | `PrivacyPolicyDraftAgent`, `DpiaAssistanceAgent`, `ConsentTextSuggestionAgent`; `AiTools` Livewire component; `/api/v1/compliance/ai/*` REST | `compliance_ai_drafts` (append-only) |
 
 Every domain follows the same pattern: a thin orchestrator service that delegates to small, interface-bound implementations. You can plug in your own implementation of any interface and the rest of the system picks it up via Laravel's container.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,9 +2,10 @@
 
 ## Requirements
 
-- PHP 8.2+
-- Laravel 10, 11, 12, or 13 (Laravel 13 requires PHP 8.3+)
+- PHP 8.3+
+- Laravel 10, 11, 12, or 13
 - A database supported by Eloquent — SQLite, MySQL, PostgreSQL, SQL Server. The schema uses standard column types (string / text / json / decimal / timestamp / boolean) so any current Laravel-supported driver works.
+- **Optional:** [`artisanpack-ui/ai`](https://github.com/ArtisanPack-UI/ai) `^1.0` to enable the AI trigger surfaces (privacy-policy draft, DPIA assistance, consent-text suggestion). The compliance package boots cleanly without it — the AI surfaces stay unregistered.
 
 ## Install via Composer
 
@@ -20,7 +21,7 @@ The service provider auto-registers — no manual `config/app.php` edits require
 php artisan migrate
 ```
 
-This creates 18 tables:
+This creates 19 tables:
 
 - `consent_policies`, `consent_records`, `consent_audit_logs`
 - `processing_activities`, `data_protection_assessments`, `assessment_risks`, `risk_mitigations`
@@ -29,6 +30,7 @@ This creates 18 tables:
 - `retention_policies`, `collection_policies`
 - `compliance_violations`, `compliance_check_results`, `compliance_scores`
 - `scheduled_compliance_reports`
+- `compliance_ai_drafts` — append-only version history for AI-generated drafts (populated only when the AI features are used)
 
 If you want to inspect or customize the migrations before running them, publish first:
 
@@ -43,6 +45,33 @@ php artisan vendor:publish --tag=compliance-config
 ```
 
 The published config lives at `config/artisanpack/compliance.php`. See [Configuration](usage.md#configuration) for the option set.
+
+## Enable the AI features (optional)
+
+If you want the AI trigger surfaces (privacy-policy draft, DPIA assistance, consent-text suggestion), install the AI package and set your provider credentials:
+
+```bash
+composer require artisanpack-ui/ai
+```
+
+Then toggle the three compliance AI features on in your app config (or in the compliance package's config file after publishing it):
+
+```php
+// config/artisanpack/ai.php
+'features' => [
+    'compliance.privacy_policy_draft' => [ 'enabled' => true ],
+    'compliance.dpia_assistance'      => [ 'enabled' => true ],
+    'compliance.consent_text'         => [ 'enabled' => true ],
+],
+```
+
+Register the `manageComplianceAiDrafts` Gate in your `AuthServiceProvider` — the compliance package ships a default-deny stub that must be overridden before any user can save AI-generated drafts:
+
+```php
+Gate::define( 'manageComplianceAiDrafts', fn ( $user ) => $user->hasRole( 'compliance-officer' ) );
+```
+
+See [Usage → AI features](usage.md#ai-features) for the full surface.
 
 ## Verify the install
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -180,6 +180,98 @@ php artisan compliance:generate-report --type=quarterly --format=pdf
 
 `ScheduledComplianceReport` rows drive cron-based recurring delivery. See [Advanced — custom report types](advanced.md#custom-report-types).
 
+## AI features
+
+*Added in 1.1.0. Requires [`artisanpack-ui/ai`](https://github.com/ArtisanPack-UI/ai). See [Installation](installation.md#enable-the-ai-features-optional) for setup.*
+
+The compliance package ships three optional AI trigger surfaces. Every output from every agent is **high-stakes** — the outputs must be reviewed by qualified legal counsel before publication. The package enforces this at three layers so no single caller can bypass it:
+
+- Every agent's output carries `requires_legal_review: true` and a non-empty `review_checklist` (the validators overwrite the model if it tries to omit them).
+- The `AiTools::saveDraft` Livewire handler requires the `manageComplianceAiDrafts` Gate to allow, the FeatureRegistry to have the feature toggled on, AND the payload to include `metadata.acknowledged === true`.
+- The `AiDraft` model is append-only — any UPDATE attempt throws, so the version history is preserved for legal review.
+
+### Agents
+
+| Feature key | Agent | Default model | Purpose |
+|---|---|---|---|
+| `compliance.privacy_policy_draft` | `PrivacyPolicyDraftAgent` | `claude-opus-4-7` | Draft a starter privacy policy from declared processing activities. |
+| `compliance.dpia_assistance` | `DpiaAssistanceAgent` | `claude-opus-4-7` | Enumerate risks, mitigations, and stakeholder impacts for a DPIA. Enforces that every risk has a matching mitigation. |
+| `compliance.consent_text` | `ConsentTextSuggestionAgent` | `claude-sonnet-4-6` | Suggest plain-language consent text with a reading-level score and jurisdiction notes. |
+
+### Trigger from Livewire
+
+Mount the transport component on any admin page:
+
+```blade
+<livewire:ap-compliance-ai-tools />
+```
+
+Dispatch an event to run an agent, then listen for the result on the browser side:
+
+```blade
+<button
+    wire:click="$dispatch('compliance-ai:draft-privacy-policy', {
+        payload: {
+            organization_name: 'Acme',
+            contact_email: 'privacy@acme.example',
+            effective_date: '2026-08-01',
+            jurisdictions: ['EU', 'US-CA'],
+            processing_activities: [
+                { purpose: 'Order fulfillment', data_categories: ['name','address'], legal_basis: 'contract', retention: '5 years' },
+            ],
+        }
+    })"
+>Draft privacy policy</button>
+
+<script>
+Livewire.on('compliance-ai:compliance.privacy_policy_draft:success', ({ output }) => {
+    // 1. Render the un-dismissable "requires legal review" banner.
+    // 2. Render the acknowledgement checkbox.
+    // 3. Only reveal output.policy_markdown after the user acknowledges.
+});
+</script>
+```
+
+Save a draft after the reviewer has acknowledged:
+
+```js
+Livewire.dispatch('compliance-ai:save-draft', {
+    featureKey: 'compliance.privacy_policy_draft',
+    output: agentOutput,
+    subjectKey: 'main-site',
+    metadata: { acknowledged: true, reviewer: 'jane@acme.example' },
+});
+```
+
+The handler emits `compliance-ai:save-draft:rejected` (with a `message`) if the Gate denies, the toggle is off, or the acknowledgement is missing; `compliance-ai:save-draft:success` (with `draft_id`) otherwise.
+
+### Trigger from React / Vue
+
+Hit the REST endpoints directly. They mount at `/api/v1/compliance/ai/*` under the `api` middleware group, guarded by the guard read from `config('artisanpack.compliance.ai.guard')` (default `sanctum`, override via `COMPLIANCE_AI_GUARD`):
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/api/v1/compliance/ai/features` | GET | Feature-toggle state map. |
+| `/api/v1/compliance/ai/privacy-policy-draft` | POST | Run `PrivacyPolicyDraftAgent`. |
+| `/api/v1/compliance/ai/dpia-assistance` | POST | Run `DpiaAssistanceAgent`. |
+| `/api/v1/compliance/ai/consent-text` | POST | Run `ConsentTextSuggestionAgent`. |
+
+Every response has the shape `{ feature: string, output: object }` on success, or `{ feature: string, error: string, message: string }` on failure. Error codes: `feature_disabled` (403), `missing_credentials` (503), `invalid_input` (422), `internal_error` (500).
+
+### Retrieve draft history
+
+Every save creates a new `AiDraft` row — the model blocks UPDATE at the ORM layer so the audit trail is immutable. Query it with the shipped scopes:
+
+```php
+use ArtisanPackUI\Compliance\Models\AiDraft;
+
+$history = AiDraft::query()
+    ->forFeature( 'compliance.privacy_policy_draft' )
+    ->forSubject( 'main-site' )
+    ->latest( 'created_at' )
+    ->get();
+```
+
 ## Configuration
 
 The published config at `config/artisanpack/compliance.php` exposes:
@@ -190,5 +282,6 @@ The published config at `config/artisanpack/compliance.php` exposes:
 - Report defaults (format, recipient list)
 - Storage disk for portability exports
 - Per-command per-run limits
+- `ai.guard` — auth guard used for the `/api/v1/compliance/ai/*` REST routes (default `sanctum`)
 
 Refer to the file inline comments for the full option set.

--- a/src/Ai/Agents/ConsentTextSuggestionAgent.php
+++ b/src/Ai/Agents/ConsentTextSuggestionAgent.php
@@ -1,0 +1,286 @@
+<?php
+
+/**
+ * Consent-text suggestion agent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Compliance
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+
+/**
+ * Suggest clear, plain-language consent text for a given processing
+ * purpose. Optimizes for readability + regulatory clarity.
+ *
+ * Lower-stakes than the policy/DPIA agents but still gated behind a
+ * `requires_legal_review` marker — consent language is enforceable.
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'purpose'          => string,       // required, what the consent covers
+ *   'data_categories'  => list<string>, // required, non-empty
+ *   'audience'         => string,       // required (e.g. "general public", "healthcare patients")
+ *   'jurisdiction'     => string,       // required (e.g. "EU", "US-CA", "BR")
+ *   'target_reading_level' => int|null, // optional grade level (6-14), default 8
+ * ]
+ * ```
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   consent_text: string,             // <= 800 chars, plain language
+ *   short_label: string,              // <= 80 chars, checkbox label
+ *   reading_level: {
+ *     grade: number,                  // Flesch-Kincaid grade
+ *     score: number,                  // Flesch reading ease
+ *   },
+ *   jurisdiction_notes: list<string>, // things a reviewer must confirm
+ *   requires_legal_review: true,
+ * }
+ * ```
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Compliance
+ *
+ * @since      1.1.0
+ */
+class ConsentTextSuggestionAgent extends ArtisanPackAgent
+{
+    /**
+     * {@inheritDoc}
+     */
+    public string $featureKey = 'compliance.consent_text';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $package = 'artisanpack-ui/compliance';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $defaultModel = 'claude-sonnet-4-6';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function instructions(): string
+    {
+        return <<<'PROMPT'
+You write consent language that a real person can understand on the first read.
+
+Non-negotiables:
+- Plain language. Target the reader's grade level (default 8). Prefer short sentences and everyday words.
+- No pre-checked-consent framing. Consent must read as an active choice.
+- Name the specific data categories and the specific purpose. No vague "your information" or "to improve our services".
+- Do not imply consent covers anything the caller did not list.
+- Jurisdiction-specific requirements matter: EU/UK (GDPR — freely given, specific, informed), US-CA (CCPA — right to opt out of sale/share), BR (LGPD — free, informed, unambiguous, specific), etc. Note relevant caveats in `jurisdiction_notes`.
+
+Return a JSON object with:
+- `consent_text` (string, <= 800 chars): the full consent paragraph.
+- `short_label` (string, <= 80 chars): a checkbox-label version, e.g. "I agree to receive product update emails.".
+- `reading_level` (object): { grade: number (Flesch-Kincaid grade), score: number (Flesch reading-ease score 0-100) }. Estimate honestly; do not fabricate.
+- `jurisdiction_notes` (list of strings): items a reviewer must confirm for the target jurisdiction.
+- `requires_legal_review` (boolean): MUST be `true`.
+PROMPT;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function outputSchema(): array
+    {
+        return [
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            'required'             => [
+                'consent_text',
+                'short_label',
+                'reading_level',
+                'jurisdiction_notes',
+                'requires_legal_review',
+            ],
+            'properties' => [
+                'consent_text'  => [ 'type' => 'string' ],
+                'short_label'   => [ 'type' => 'string' ],
+                'reading_level' => [
+                    'type'                 => 'object',
+                    'additionalProperties' => false,
+                    'required'             => [ 'grade', 'score' ],
+                    'properties'           => [
+                        'grade' => [ 'type' => 'number' ],
+                        'score' => [ 'type' => 'number' ],
+                    ],
+                ],
+                'jurisdiction_notes' => [
+                    'type'  => 'array',
+                    'items' => [ 'type' => 'string' ],
+                ],
+                'requires_legal_review' => [ 'type' => 'boolean' ],
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute( Credentials $credentials, string $model, string $instructions ): array
+    {
+        $normalized = $this->normalizeInput( $this->input() );
+
+        $prompter = app( AgentPrompter::class );
+
+        $result = $prompter->prompt(
+            credentials: $credentials,
+            model: $model,
+            instructions: $instructions,
+            message: $this->buildMessage( $normalized ),
+            outputSchema: $this->outputSchema(),
+        );
+
+        return [
+            'output'        => $this->validateOutput( $result['output'] ?? [] ),
+            'input_tokens'  => (int) ( $result['input_tokens'] ?? 0 ),
+            'output_tokens' => (int) ( $result['output_tokens'] ?? 0 ),
+        ];
+    }
+
+    /**
+     * @return array{
+     *     purpose: string,
+     *     data_categories: list<string>,
+     *     audience: string,
+     *     jurisdiction: string,
+     *     target_reading_level: int,
+     * }
+     */
+    protected function normalizeInput( mixed $input ): array
+    {
+        if ( ! is_array( $input ) ) {
+            throw FeatureError::forFeature( $this->featureKey, 'input must be an array.' );
+        }
+
+        foreach ( [ 'purpose', 'audience', 'jurisdiction' ] as $key ) {
+            if ( ! isset( $input[ $key ] ) || ! is_string( $input[ $key ] ) || '' === trim( $input[ $key ] ) ) {
+                throw FeatureError::forFeature( $this->featureKey, sprintf( '`%s` must be a non-empty string.', $key ) );
+            }
+        }
+
+        if ( ! isset( $input['data_categories'] ) || ! is_array( $input['data_categories'] ) || [] === $input['data_categories'] ) {
+            throw FeatureError::forFeature( $this->featureKey, '`data_categories` must be a non-empty array.' );
+        }
+
+        $grade = 8;
+        if ( isset( $input['target_reading_level'] ) ) {
+            $parsed = filter_var(
+                $input['target_reading_level'],
+                FILTER_VALIDATE_INT,
+                [ 'options' => [ 'min_range' => 6, 'max_range' => 14 ] ],
+            );
+            if ( false !== $parsed ) {
+                $grade = $parsed;
+            }
+        }
+
+        return [
+            'purpose'              => trim( $input['purpose'] ),
+            'data_categories'      => array_values( array_map( 'strval', $input['data_categories'] ) ),
+            'audience'             => trim( $input['audience'] ),
+            'jurisdiction'         => trim( $input['jurisdiction'] ),
+            'target_reading_level' => $grade,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     *
+     * @return array<int, array<string, string>>
+     */
+    protected function buildMessage( array $input ): array
+    {
+        return [
+            [
+                'type' => 'text',
+                'text' => sprintf(
+                    "Purpose: %s\nAudience: %s\nJurisdiction: %s\nTarget grade level: %d",
+                    $input['purpose'],
+                    $input['audience'],
+                    $input['jurisdiction'],
+                    $input['target_reading_level'],
+                ),
+            ],
+            [
+                'type' => 'text',
+                'text' => 'Data categories: ' . implode( ', ', $input['data_categories'] ),
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $output
+     *
+     * @return array<string, mixed>
+     */
+    protected function validateOutput( array $output ): array
+    {
+        $consent = isset( $output['consent_text'] ) ? trim( (string) $output['consent_text'] ) : '';
+        $label   = isset( $output['short_label'] ) ? trim( (string) $output['short_label'] ) : '';
+
+        if ( '' === $consent ) {
+            throw FeatureError::forFeature( $this->featureKey, 'model returned empty consent text.' );
+        }
+
+        if ( '' === $label ) {
+            throw FeatureError::forFeature(
+                $this->featureKey,
+                'model returned an empty short_label — an unlabelled consent checkbox does not meet the "clear affirmative act" standard.',
+            );
+        }
+
+        if ( mb_strlen( $consent ) > 800 ) {
+            $consent = mb_substr( $consent, 0, 800 );
+        }
+
+        if ( mb_strlen( $label ) > 80 ) {
+            $label = mb_substr( $label, 0, 80 );
+        }
+
+        $reading = $output['reading_level'] ?? null;
+        $grade   = is_array( $reading ) && isset( $reading['grade'] ) && is_numeric( $reading['grade'] ) ? (float) $reading['grade'] : 0.0;
+        $score   = is_array( $reading ) && isset( $reading['score'] ) && is_numeric( $reading['score'] ) ? (float) $reading['score'] : 0.0;
+
+        $notes = [];
+        if ( isset( $output['jurisdiction_notes'] ) && is_array( $output['jurisdiction_notes'] ) ) {
+            foreach ( $output['jurisdiction_notes'] as $note ) {
+                if ( is_string( $note ) && '' !== trim( $note ) ) {
+                    $notes[] = trim( $note );
+                }
+            }
+        }
+
+        if ( [] === $notes ) {
+            $notes = [ 'Have qualified legal counsel confirm the language meets the target jurisdiction\'s consent standard.' ];
+        }
+
+        return [
+            'consent_text'          => $consent,
+            'short_label'           => $label,
+            'reading_level'         => [ 'grade' => $grade, 'score' => $score ],
+            'jurisdiction_notes'    => $notes,
+            'requires_legal_review' => true,
+        ];
+    }
+}

--- a/src/Ai/Agents/DpiaAssistanceAgent.php
+++ b/src/Ai/Agents/DpiaAssistanceAgent.php
@@ -1,0 +1,350 @@
+<?php
+
+/**
+ * DPIA (Data Protection Impact Assessment) assistance agent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Compliance
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+
+/**
+ * Assists with DPIA drafting: enumerates risks, suggests mitigations,
+ * and calls out stakeholder impacts.
+ *
+ * **High-stakes agent**: every output carries a `requires_legal_review`
+ * marker and a mandatory review checklist. The host UI must gate the
+ * draft behind a legal-review acknowledgement.
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'activity_name'      => string,          // required
+ *   'activity_purpose'   => string,          // required
+ *   'data_categories'    => list<string>,    // required, non-empty
+ *   'data_subjects'      => list<string>,    // required, non-empty (e.g. "customers", "employees")
+ *   'processing_scale'   => string,          // required (e.g. "small", "medium", "large")
+ *   'systems_involved'   => list<string>,    // optional
+ *   'transfers_outside_eea' => bool,         // optional (defaults false)
+ * ]
+ * ```
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   risks: list<{
+ *     title: string,
+ *     description: string,
+ *     likelihood: "low"|"medium"|"high",
+ *     severity: "low"|"medium"|"high",
+ *     affected_subjects: list<string>,
+ *   }>,
+ *   mitigations: list<{
+ *     risk_title: string,
+ *     mitigation: string,
+ *     residual_risk: "low"|"medium"|"high",
+ *   }>,
+ *   stakeholder_impacts: list<{
+ *     stakeholder: string,
+ *     impact: string,
+ *   }>,
+ *   requires_legal_review: true,
+ *   review_checklist: list<string>,
+ * }
+ * ```
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Compliance
+ *
+ * @since      1.1.0
+ */
+class DpiaAssistanceAgent extends ArtisanPackAgent
+{
+
+    private const RISK_LEVELS = [ 'low', 'medium', 'high' ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $featureKey = 'compliance.dpia_assistance';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $package = 'artisanpack-ui/compliance';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $defaultModel = 'claude-opus-4-7';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function instructions(): string
+    {
+        return <<<'PROMPT'
+You assist with drafting a Data Protection Impact Assessment (DPIA). You are not a lawyer or a DPO and the output is not legal advice.
+
+Non-negotiables:
+- Draft is a STARTING POINT that a DPO or qualified legal counsel must review and validate.
+- Base every risk, mitigation, and stakeholder impact on the declared processing activity. Do NOT invent facts.
+- Rate likelihood and severity honestly. A "low" severity for the loss of medical data is wrong.
+- Prefer specific mitigations ("encrypt payload column with libsodium XChaCha20-Poly1305") over vague ones ("use encryption").
+- Every risk you enumerate MUST have a matching mitigation entry (linked by `risk_title`).
+- Call out cross-border transfers, automated decision-making, and processing of special-category data as distinct risks when applicable.
+
+Return a JSON object with:
+- `risks`: list of risk objects (title, description, likelihood in ["low","medium","high"], severity in ["low","medium","high"], affected_subjects list).
+- `mitigations`: list of mitigation objects (risk_title matching a risk, mitigation description, residual_risk level).
+- `stakeholder_impacts`: list of impact objects (stakeholder identifier, impact description).
+- `requires_legal_review`: MUST be `true`.
+- `review_checklist`: list of items the reviewing DPO/counsel must verify (e.g. "Confirm Article 35(3) mandatory-DPIA criteria assessed correctly"). Include at minimum: risk ratings, mitigation effectiveness, any special-category data handling, and cross-border-transfer safeguards.
+PROMPT;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function outputSchema(): array
+    {
+        return [
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            'required'             => [
+                'risks',
+                'mitigations',
+                'stakeholder_impacts',
+                'requires_legal_review',
+                'review_checklist',
+            ],
+            'properties' => [
+                'risks' => [
+                    'type'     => 'array',
+                    'minItems' => 1,
+                    'items'    => [
+                        'type'                 => 'object',
+                        'additionalProperties' => false,
+                        'required'             => [ 'title', 'description', 'likelihood', 'severity', 'affected_subjects' ],
+                        'properties'           => [
+                            'title'             => [ 'type' => 'string' ],
+                            'description'       => [ 'type' => 'string' ],
+                            'likelihood'        => [ 'type' => 'string', 'enum' => self::RISK_LEVELS ],
+                            'severity'          => [ 'type' => 'string', 'enum' => self::RISK_LEVELS ],
+                            'affected_subjects' => [
+                                'type'  => 'array',
+                                'items' => [ 'type' => 'string' ],
+                            ],
+                        ],
+                    ],
+                ],
+                'mitigations' => [
+                    'type'  => 'array',
+                    'items' => [
+                        'type'                 => 'object',
+                        'additionalProperties' => false,
+                        'required'             => [ 'risk_title', 'mitigation', 'residual_risk' ],
+                        'properties'           => [
+                            'risk_title'    => [ 'type' => 'string' ],
+                            'mitigation'    => [ 'type' => 'string' ],
+                            'residual_risk' => [ 'type' => 'string', 'enum' => self::RISK_LEVELS ],
+                        ],
+                    ],
+                ],
+                'stakeholder_impacts' => [
+                    'type'  => 'array',
+                    'items' => [
+                        'type'                 => 'object',
+                        'additionalProperties' => false,
+                        'required'             => [ 'stakeholder', 'impact' ],
+                        'properties'           => [
+                            'stakeholder' => [ 'type' => 'string' ],
+                            'impact'      => [ 'type' => 'string' ],
+                        ],
+                    ],
+                ],
+                'requires_legal_review' => [ 'type' => 'boolean' ],
+                'review_checklist'      => [
+                    'type'     => 'array',
+                    'minItems' => 1,
+                    'items'    => [ 'type' => 'string' ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute( Credentials $credentials, string $model, string $instructions ): array
+    {
+        $normalized = $this->normalizeInput( $this->input() );
+
+        $prompter = app( AgentPrompter::class );
+
+        $result = $prompter->prompt(
+            credentials: $credentials,
+            model: $model,
+            instructions: $instructions,
+            message: $this->buildMessage( $normalized ),
+            outputSchema: $this->outputSchema(),
+        );
+
+        return [
+            'output'        => $this->validateOutput( $result['output'] ?? [] ),
+            'input_tokens'  => (int) ( $result['input_tokens'] ?? 0 ),
+            'output_tokens' => (int) ( $result['output_tokens'] ?? 0 ),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function normalizeInput( mixed $input ): array
+    {
+        if ( ! is_array( $input ) ) {
+            throw FeatureError::forFeature( $this->featureKey, 'input must be an array.' );
+        }
+
+        $required = [ 'activity_name', 'activity_purpose', 'processing_scale' ];
+        foreach ( $required as $key ) {
+            if ( ! isset( $input[ $key ] ) || ! is_string( $input[ $key ] ) || '' === trim( $input[ $key ] ) ) {
+                throw FeatureError::forFeature( $this->featureKey, sprintf( '`%s` must be a non-empty string.', $key ) );
+            }
+        }
+
+        foreach ( [ 'data_categories', 'data_subjects' ] as $listKey ) {
+            if ( ! isset( $input[ $listKey ] ) || ! is_array( $input[ $listKey ] ) || [] === $input[ $listKey ] ) {
+                throw FeatureError::forFeature( $this->featureKey, sprintf( '`%s` must be a non-empty array.', $listKey ) );
+            }
+        }
+
+        $systems = isset( $input['systems_involved'] ) && is_array( $input['systems_involved'] )
+            ? array_values( array_map( 'strval', $input['systems_involved'] ) )
+            : [];
+
+        return [
+            'activity_name'         => trim( $input['activity_name'] ),
+            'activity_purpose'      => trim( $input['activity_purpose'] ),
+            'data_categories'       => array_values( array_map( 'strval', $input['data_categories'] ) ),
+            'data_subjects'         => array_values( array_map( 'strval', $input['data_subjects'] ) ),
+            'processing_scale'      => trim( $input['processing_scale'] ),
+            'systems_involved'      => $systems,
+            'transfers_outside_eea' => (bool) ( $input['transfers_outside_eea'] ?? false ),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     *
+     * @return array<int, array<string, string>>
+     */
+    protected function buildMessage( array $input ): array
+    {
+        return [
+            [
+                'type' => 'text',
+                'text' => sprintf(
+                    "Activity: %s\nPurpose: %s\nProcessing scale: %s\nTransfers outside EEA: %s",
+                    $input['activity_name'],
+                    $input['activity_purpose'],
+                    $input['processing_scale'],
+                    $input['transfers_outside_eea'] ? 'yes' : 'no',
+                ),
+            ],
+            [
+                'type' => 'text',
+                'text' => "Context (JSON):\n" . json_encode( [
+                    'data_categories'  => $input['data_categories'],
+                    'data_subjects'    => $input['data_subjects'],
+                    'systems_involved' => $input['systems_involved'],
+                ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ),
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $output
+     *
+     * @return array<string, mixed>
+     */
+    protected function validateOutput( array $output ): array
+    {
+        $risks       = $this->normalizeList( $output['risks'] ?? null );
+        $mitigations = $this->normalizeList( $output['mitigations'] ?? null );
+        $impacts     = $this->normalizeList( $output['stakeholder_impacts'] ?? null );
+
+        if ( [] === $risks ) {
+            throw FeatureError::forFeature( $this->featureKey, 'model returned no risks.' );
+        }
+
+        $mitigationTitles = [];
+        foreach ( $mitigations as $mitigation ) {
+            if ( isset( $mitigation['risk_title'] ) && is_string( $mitigation['risk_title'] ) ) {
+                $mitigationTitles[] = trim( $mitigation['risk_title'] );
+            }
+        }
+
+        foreach ( $risks as $risk ) {
+            $title = isset( $risk['title'] ) && is_string( $risk['title'] ) ? trim( $risk['title'] ) : '';
+
+            if ( '' === $title || ! in_array( $title, $mitigationTitles, true ) ) {
+                throw FeatureError::forFeature(
+                    $this->featureKey,
+                    sprintf( 'Every risk must have a matching mitigation. Risk "%s" has none.', $title ),
+                );
+            }
+        }
+
+        $checklist = [];
+        if ( isset( $output['review_checklist'] ) && is_array( $output['review_checklist'] ) ) {
+            foreach ( $output['review_checklist'] as $item ) {
+                if ( is_string( $item ) && '' !== trim( $item ) ) {
+                    $checklist[] = trim( $item );
+                }
+            }
+        }
+
+        if ( [] === $checklist ) {
+            $checklist = [ 'Have a DPO or qualified legal counsel review the DPIA before it is filed.' ];
+        }
+
+        return [
+            'risks'                 => $risks,
+            'mitigations'           => $mitigations,
+            'stakeholder_impacts'   => $impacts,
+            'requires_legal_review' => true,
+            'review_checklist'      => $checklist,
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function normalizeList( mixed $value ): array
+    {
+        if ( ! is_array( $value ) ) {
+            return [];
+        }
+
+        $out = [];
+        foreach ( $value as $item ) {
+            if ( is_array( $item ) ) {
+                $out[] = $item;
+            }
+        }
+        return $out;
+    }
+}

--- a/src/Ai/Agents/PrivacyPolicyDraftAgent.php
+++ b/src/Ai/Agents/PrivacyPolicyDraftAgent.php
@@ -1,0 +1,314 @@
+<?php
+
+/**
+ * Privacy-policy draft agent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Compliance
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+
+/**
+ * Generate a starter privacy policy from declared processing activities.
+ *
+ * **High-stakes agent**: every output carries an un-dismissable
+ * `requires_legal_review` marker and a mandatory review checklist. The
+ * agent itself never claims regulatory sufficiency — the host UI must
+ * gate the draft behind a legal-review acknowledgement and persist
+ * every run as a new {@see \ArtisanPackUI\Compliance\Models\AiDraft}
+ * row (never overwriting a prior version).
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'organization_name'    => string,     // required
+ *   'processing_activities' => list<array{
+ *       purpose: string,
+ *       data_categories: list<string>,
+ *       legal_basis: string,
+ *       retention: string,
+ *       recipients?: list<string>,
+ *   }>,                                    // required, non-empty
+ *   'jurisdictions'         => list<string>, // required, non-empty
+ *   'contact_email'         => string,     // required
+ *   'effective_date'        => string,     // required, YYYY-MM-DD
+ * ]
+ * ```
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   policy_markdown: string,           // full policy body in markdown
+ *   section_headings: list<string>,    // top-level H2 headings, in order
+ *   requires_legal_review: true,       // always true, never omit
+ *   review_checklist: list<string>,    // items a lawyer must confirm
+ *   jurisdiction_notes: map<string,string>, // per-jurisdiction caveats
+ * }
+ * ```
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Compliance
+ *
+ * @since      1.1.0
+ */
+class PrivacyPolicyDraftAgent extends ArtisanPackAgent
+{
+    /**
+     * {@inheritDoc}
+     */
+    public string $featureKey = 'compliance.privacy_policy_draft';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $package = 'artisanpack-ui/compliance';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $defaultModel = 'claude-opus-4-7';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function instructions(): string
+    {
+        return <<<'PROMPT'
+You draft a STARTER privacy policy from a set of declared processing activities. You are not a lawyer and the output is not legal advice.
+
+Non-negotiables:
+- The output is a starting point that MUST be reviewed by qualified legal counsel before publication.
+- Base every claim strictly on the declared processing activities. Do NOT invent categories of data, retention periods, third-party recipients, or legal bases the caller did not supply.
+- Use plain, direct language. Prefer concrete sentences over regulatory boilerplate.
+- Structure the policy with standard H2 sections: What data we collect, How we use it, Legal basis, Who we share it with, How long we keep it, Your rights, How to contact us. Add jurisdiction-specific sections where relevant (e.g. CCPA "Do Not Sell", GDPR data-subject rights, LGPD holder rights).
+- If the caller supplied conflicting or ambiguous data, note the conflict in `review_checklist` rather than resolving it silently.
+
+Return a JSON object with these keys:
+- `policy_markdown` (string): the full policy body as GitHub-flavored markdown, starting with a top-level H1 title.
+- `section_headings` (list of strings): the H2 headings you used, in document order.
+- `requires_legal_review` (boolean): MUST be `true`.
+- `review_checklist` (list of strings): specific items a reviewing attorney must verify (e.g. "Confirm the 90-day retention on marketing data is defensible under CCPA §1798.100"). Include at minimum: jurisdiction-specific requirements, retention periods, third-party recipients, and any ambiguities you flagged.
+- `jurisdiction_notes` (object mapping jurisdiction code → note string): per-jurisdiction caveats the reviewer should double-check.
+PROMPT;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function outputSchema(): array
+    {
+        return [
+            'type'                 => 'object',
+            'additionalProperties' => false,
+            'required'             => [
+                'policy_markdown',
+                'section_headings',
+                'requires_legal_review',
+                'review_checklist',
+                'jurisdiction_notes',
+            ],
+            'properties' => [
+                'policy_markdown'       => [ 'type' => 'string' ],
+                'section_headings'      => [
+                    'type'  => 'array',
+                    'items' => [ 'type' => 'string' ],
+                ],
+                'requires_legal_review' => [ 'type' => 'boolean' ],
+                'review_checklist'      => [
+                    'type'     => 'array',
+                    'minItems' => 1,
+                    'items'    => [ 'type' => 'string' ],
+                ],
+                'jurisdiction_notes'    => [
+                    'type'                 => 'object',
+                    'additionalProperties' => [ 'type' => 'string' ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute( Credentials $credentials, string $model, string $instructions ): array
+    {
+        $normalized = $this->normalizeInput( $this->input() );
+
+        $prompter = app( AgentPrompter::class );
+
+        $result = $prompter->prompt(
+            credentials: $credentials,
+            model: $model,
+            instructions: $instructions,
+            message: $this->buildMessage( $normalized ),
+            outputSchema: $this->outputSchema(),
+        );
+
+        return [
+            'output'        => $this->validateOutput( $result['output'] ?? [] ),
+            'input_tokens'  => (int) ( $result['input_tokens'] ?? 0 ),
+            'output_tokens' => (int) ( $result['output_tokens'] ?? 0 ),
+        ];
+    }
+
+    /**
+     * Validate and shape the raw agent input.
+     *
+     * @return array{
+     *     organization_name: string,
+     *     processing_activities: list<array<string, mixed>>,
+     *     jurisdictions: list<string>,
+     *     contact_email: string,
+     *     effective_date: string,
+     * }
+     */
+    protected function normalizeInput( mixed $input ): array
+    {
+        if ( ! is_array( $input ) ) {
+            throw FeatureError::forFeature( $this->featureKey, 'input must be an array.' );
+        }
+
+        $org           = isset( $input['organization_name'] ) && is_string( $input['organization_name'] ) ? trim( $input['organization_name'] ) : '';
+        $contact       = isset( $input['contact_email'] ) && is_string( $input['contact_email'] ) ? trim( $input['contact_email'] ) : '';
+        $effectiveDate = isset( $input['effective_date'] ) && is_string( $input['effective_date'] ) ? trim( $input['effective_date'] ) : '';
+        $activities    = $input['processing_activities'] ?? null;
+        $jurisdictions = $input['jurisdictions'] ?? null;
+
+        if ( '' === $org ) {
+            throw FeatureError::forFeature( $this->featureKey, '`organization_name` is required.' );
+        }
+
+        if ( '' === $contact || false === filter_var( $contact, FILTER_VALIDATE_EMAIL ) ) {
+            throw FeatureError::forFeature( $this->featureKey, '`contact_email` must be a valid email address.' );
+        }
+
+        if ( '' === $effectiveDate || 1 !== preg_match( '/^\d{4}-\d{2}-\d{2}$/', $effectiveDate ) ) {
+            throw FeatureError::forFeature( $this->featureKey, '`effective_date` must be a YYYY-MM-DD string.' );
+        }
+
+        if ( ! is_array( $activities ) || [] === $activities ) {
+            throw FeatureError::forFeature( $this->featureKey, '`processing_activities` must be a non-empty array.' );
+        }
+
+        foreach ( $activities as $index => $activity ) {
+            if ( ! is_array( $activity ) ) {
+                throw FeatureError::forFeature(
+                    $this->featureKey,
+                    sprintf( '`processing_activities[%s]` must be an object with keys purpose, data_categories, legal_basis, retention.', (string) $index ),
+                );
+            }
+        }
+
+        if ( ! is_array( $jurisdictions ) || [] === $jurisdictions ) {
+            throw FeatureError::forFeature( $this->featureKey, '`jurisdictions` must be a non-empty array.' );
+        }
+
+        return [
+            'organization_name'     => $org,
+            'processing_activities' => array_values( $activities ),
+            'jurisdictions'         => array_values( array_map( 'strval', $jurisdictions ) ),
+            'contact_email'         => $contact,
+            'effective_date'        => $effectiveDate,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     *
+     * @return array<int, array<string, string>>
+     */
+    protected function buildMessage( array $input ): array
+    {
+        return [
+            [
+                'type' => 'text',
+                'text' => sprintf(
+                    "Organization: %s\nContact email: %s\nEffective date: %s\nJurisdictions: %s",
+                    $input['organization_name'],
+                    $input['contact_email'],
+                    $input['effective_date'],
+                    implode( ', ', $input['jurisdictions'] ),
+                ),
+            ],
+            [
+                'type' => 'text',
+                'text' => "Processing activities (JSON):\n" . json_encode( $input['processing_activities'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ),
+            ],
+        ];
+    }
+
+    /**
+     * Enforce output invariants — coerce `requires_legal_review` to true
+     * and guarantee a non-empty review checklist even if the model tries
+     * to omit them.
+     *
+     * @param  array<string, mixed>  $output
+     *
+     * @return array{
+     *     policy_markdown: string,
+     *     section_headings: list<string>,
+     *     requires_legal_review: true,
+     *     review_checklist: list<string>,
+     *     jurisdiction_notes: array<string, string>,
+     * }
+     */
+    protected function validateOutput( array $output ): array
+    {
+        $policy = isset( $output['policy_markdown'] ) ? trim( (string) $output['policy_markdown'] ) : '';
+
+        if ( '' === $policy ) {
+            throw FeatureError::forFeature( $this->featureKey, 'model returned an empty policy body.' );
+        }
+
+        $headings = [];
+        if ( isset( $output['section_headings'] ) && is_array( $output['section_headings'] ) ) {
+            foreach ( $output['section_headings'] as $heading ) {
+                if ( is_string( $heading ) && '' !== trim( $heading ) ) {
+                    $headings[] = trim( $heading );
+                }
+            }
+        }
+
+        $checklist = [];
+        if ( isset( $output['review_checklist'] ) && is_array( $output['review_checklist'] ) ) {
+            foreach ( $output['review_checklist'] as $item ) {
+                if ( is_string( $item ) && '' !== trim( $item ) ) {
+                    $checklist[] = trim( $item );
+                }
+            }
+        }
+
+        if ( [] === $checklist ) {
+            $checklist = [ 'Have qualified legal counsel review the entire draft before publication.' ];
+        }
+
+        $notes = [];
+        if ( isset( $output['jurisdiction_notes'] ) && is_array( $output['jurisdiction_notes'] ) ) {
+            foreach ( $output['jurisdiction_notes'] as $key => $value ) {
+                if ( is_string( $key ) && is_string( $value ) ) {
+                    $notes[ $key ] = $value;
+                }
+            }
+        }
+
+        return [
+            'policy_markdown'       => $policy,
+            'section_headings'      => $headings,
+            'requires_legal_review' => true,
+            'review_checklist'      => $checklist,
+            'jurisdiction_notes'    => $notes,
+        ];
+    }
+}

--- a/src/ComplianceServiceProvider.php
+++ b/src/ComplianceServiceProvider.php
@@ -15,6 +15,10 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\Compliance;
 
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Compliance\Ai\Agents\ConsentTextSuggestionAgent;
+use ArtisanPackUI\Compliance\Ai\Agents\DpiaAssistanceAgent;
+use ArtisanPackUI\Compliance\Ai\Agents\PrivacyPolicyDraftAgent;
 use ArtisanPackUI\Compliance\Compliance\Assessment\DpiaService;
 use ArtisanPackUI\Compliance\Compliance\Assessment\ProcessingActivityService;
 use ArtisanPackUI\Compliance\Compliance\Assessment\RiskCalculator;
@@ -43,10 +47,13 @@ use ArtisanPackUI\Compliance\Events\DataExportCompleted;
 use ArtisanPackUI\Compliance\Events\DataExportRequested;
 use ArtisanPackUI\Compliance\Events\ErasureCompleted;
 use ArtisanPackUI\Compliance\Events\ErasureRequested;
+use ArtisanPackUI\Compliance\Livewire\Ai\AiTools;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use Livewire\Livewire;
 
 /**
  * Service provider for the Compliance package.
@@ -58,6 +65,55 @@ use Illuminate\Support\ServiceProvider;
  */
 class ComplianceServiceProvider extends ServiceProvider
 {
+    /**
+     * The full set of AI feature keys the compliance package exposes.
+     *
+     * Single source of truth: {@see AiController::features()},
+     * {@see AiTools::enabledFeatures()}, and any host bundle wiring
+     * (React/Vue apps that hit `/api/v1/compliance/ai/features`) all
+     * read from here so a future compliance AI feature only lands in
+     * one place.
+     *
+     * @since 1.1.0
+     *
+     * @var array<int, string>
+     */
+    public const AI_FEATURE_KEYS = [
+        'compliance.privacy_policy_draft',
+        'compliance.dpia_assistance',
+        'compliance.consent_text',
+    ];
+
+    /**
+     * Declare the AI features this package owns.
+     *
+     * Auto-discovered by `artisanpack-ui/ai`'s FeatureRegistry. When the
+     * AI package is absent this method is never called and has no
+     * effect — the compliance package still boots without AI wiring,
+     * and the Livewire component + REST endpoints stay unregistered.
+     *
+     * @since 1.1.0
+     *
+     * @return array<string, array{ agent: class-string, package: string }>
+     */
+    public function aiFeatures(): array
+    {
+        return [
+            'compliance.privacy_policy_draft' => [
+                'agent'   => PrivacyPolicyDraftAgent::class,
+                'package' => 'artisanpack-ui/compliance',
+            ],
+            'compliance.dpia_assistance'      => [
+                'agent'   => DpiaAssistanceAgent::class,
+                'package' => 'artisanpack-ui/compliance',
+            ],
+            'compliance.consent_text'         => [
+                'agent'   => ConsentTextSuggestionAgent::class,
+                'package' => 'artisanpack-ui/compliance',
+            ],
+        ];
+    }
+
     /**
      * Register container bindings.
      */
@@ -108,6 +164,33 @@ class ComplianceServiceProvider extends ServiceProvider
         }
 
         $this->registerComplianceDashboardGate();
+
+        $this->registerAiSurfaces();
+    }
+
+    /**
+     * Registers the compliance AI trigger surfaces (Livewire component +
+     * `/api/v1/compliance/ai/*` REST endpoints).
+     *
+     * Both are guarded on the {@see FeatureRegistry} contract from
+     * `artisanpack-ui/ai`: when the AI package isn't installed the
+     * registrations are skipped so the compliance package still boots.
+     *
+     * @since 1.1.0
+     */
+    protected function registerAiSurfaces(): void
+    {
+        if ( ! interface_exists( FeatureRegistry::class ) ) {
+            return;
+        }
+
+        if ( class_exists( Livewire::class ) ) {
+            Livewire::component( 'ap-compliance-ai-tools', AiTools::class );
+        }
+
+        Route::prefix( 'api/v1/compliance/ai' )
+            ->middleware( 'api' )
+            ->group( __DIR__ . '/Http/routes/ai.php' );
     }
 
     /**
@@ -244,7 +327,11 @@ class ComplianceServiceProvider extends ServiceProvider
     protected function registerComplianceDashboardGate(): void
     {
         if ( ! Gate::has( 'viewComplianceDashboard' ) ) {
-            Gate::define( 'viewComplianceDashboard', fn ( $user ) => false);
+            Gate::define( 'viewComplianceDashboard', fn ( $user ) => false );
+        }
+
+        if ( ! Gate::has( 'manageComplianceAiDrafts' ) ) {
+            Gate::define( 'manageComplianceAiDrafts', fn ( $user ) => false );
         }
     }
 }

--- a/src/Http/Controllers/Ai/AiController.php
+++ b/src/Http/Controllers/Ai/AiController.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * JSON API controller for the compliance AI trigger surface.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Compliance
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Http\Controllers\Ai;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\Compliance\Ai\Agents\ConsentTextSuggestionAgent;
+use ArtisanPackUI\Compliance\Ai\Agents\DpiaAssistanceAgent;
+use ArtisanPackUI\Compliance\Ai\Agents\PrivacyPolicyDraftAgent;
+use ArtisanPackUI\Compliance\ComplianceServiceProvider;
+use ArtisanPackUI\Compliance\Http\Requests\Ai\ConsentTextRequest;
+use ArtisanPackUI\Compliance\Http\Requests\Ai\DpiaAssistanceRequest;
+use ArtisanPackUI\Compliance\Http\Requests\Ai\PrivacyPolicyDraftRequest;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * REST surface for React / Vue / any non-Livewire host. Kept
+ * framework-agnostic — front-end packages consume `/api/v1/compliance/ai/*`
+ * directly and never need to know about the individual agents.
+ *
+ * Feature-toggle enforcement lives inside the agents. This controller
+ * only wraps errors in a consistent JSON envelope.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Compliance
+ *
+ * @since      1.1.0
+ */
+class AiController
+{
+    /**
+     * Return the enabled state of the three compliance.* features so a
+     * front-end can decide which affordances to render.
+     */
+    public function features(): JsonResponse
+    {
+        /** @var FeatureRegistry $registry */
+        $registry = app( FeatureRegistry::class );
+
+        $state = [];
+        foreach ( ComplianceServiceProvider::AI_FEATURE_KEYS as $key ) {
+            $state[ $key ] = null !== $registry->get( $key ) && $registry->isToggleOn( $key );
+        }
+
+        return new JsonResponse( [ 'features' => $state ] );
+    }
+
+    /**
+     * POST /privacy-policy-draft.
+     */
+    public function privacyPolicyDraft( PrivacyPolicyDraftRequest $request ): JsonResponse
+    {
+        return $this->runAgent(
+            'compliance.privacy_policy_draft',
+            fn () => PrivacyPolicyDraftAgent::for( $request->validated() )->run(),
+        );
+    }
+
+    /**
+     * POST /dpia-assistance.
+     */
+    public function dpiaAssistance( DpiaAssistanceRequest $request ): JsonResponse
+    {
+        return $this->runAgent(
+            'compliance.dpia_assistance',
+            fn () => DpiaAssistanceAgent::for( $request->validated() )->run(),
+        );
+    }
+
+    /**
+     * POST /consent-text.
+     */
+    public function consentText( ConsentTextRequest $request ): JsonResponse
+    {
+        return $this->runAgent(
+            'compliance.consent_text',
+            fn () => ConsentTextSuggestionAgent::for( $request->validated() )->run(),
+        );
+    }
+
+    /**
+     * Shared wrapper — normalizes agent exceptions into consistent
+     * JSON envelopes.
+     */
+    private function runAgent( string $featureKey, callable $callback ): JsonResponse
+    {
+        try {
+            $output = $callback();
+            return new JsonResponse( [
+                'feature' => $featureKey,
+                'output'  => $output,
+            ] );
+        } catch ( FeatureDisabledException $e ) {
+            return new JsonResponse( [
+                'feature' => $featureKey,
+                'error'   => 'feature_disabled',
+                'message' => $e->getMessage(),
+            ], 403 );
+        } catch ( MissingCredentialsException $e ) {
+            return new JsonResponse( [
+                'feature' => $featureKey,
+                'error'   => 'missing_credentials',
+                'message' => $e->getMessage(),
+            ], 503 );
+        } catch ( FeatureError $e ) {
+            return new JsonResponse( [
+                'feature' => $featureKey,
+                'error'   => 'invalid_input',
+                'message' => $e->getMessage(),
+            ], 422 );
+        } catch ( Throwable $e ) {
+            Log::error( 'compliance AI API call failed', [
+                'feature' => $featureKey,
+                'error'   => $e->getMessage(),
+            ] );
+            return new JsonResponse( [
+                'feature' => $featureKey,
+                'error'   => 'internal_error',
+                'message' => 'Unexpected error running AI feature.',
+            ], 500 );
+        }
+    }
+}

--- a/src/Http/Requests/Ai/ConsentTextRequest.php
+++ b/src/Http/Requests/Ai/ConsentTextRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Form request for the consent-text suggestion AI endpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Compliance
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Http\Requests\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ConsentTextRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'purpose'              => [ 'required', 'string' ],
+            'audience'             => [ 'required', 'string', 'max:255' ],
+            'jurisdiction'         => [ 'required', 'string', 'max:32' ],
+            'data_categories'      => [ 'required', 'array', 'min:1' ],
+            'data_categories.*'    => [ 'required', 'string' ],
+            'target_reading_level' => [ 'nullable', 'integer', 'between:6,14' ],
+        ];
+    }
+}

--- a/src/Http/Requests/Ai/DpiaAssistanceRequest.php
+++ b/src/Http/Requests/Ai/DpiaAssistanceRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * Form request for the DPIA assistance AI endpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Compliance
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Http\Requests\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DpiaAssistanceRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'activity_name'          => [ 'required', 'string', 'max:255' ],
+            'activity_purpose'       => [ 'required', 'string' ],
+            'processing_scale'       => [ 'required', 'string', 'max:64' ],
+            'data_categories'        => [ 'required', 'array', 'min:1' ],
+            'data_categories.*'      => [ 'required', 'string' ],
+            'data_subjects'          => [ 'required', 'array', 'min:1' ],
+            'data_subjects.*'        => [ 'required', 'string' ],
+            'systems_involved'       => [ 'nullable', 'array' ],
+            'systems_involved.*'     => [ 'string' ],
+            'transfers_outside_eea'  => [ 'nullable', 'boolean' ],
+        ];
+    }
+}

--- a/src/Http/Requests/Ai/PrivacyPolicyDraftRequest.php
+++ b/src/Http/Requests/Ai/PrivacyPolicyDraftRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Form request for the privacy-policy draft AI endpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Compliance
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Http\Requests\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PrivacyPolicyDraftRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'organization_name'                         => [ 'required', 'string', 'max:255' ],
+            'contact_email'                             => [ 'required', 'email' ],
+            'effective_date'                            => [ 'required', 'date_format:Y-m-d' ],
+            'jurisdictions'                             => [ 'required', 'array', 'min:1' ],
+            'jurisdictions.*'                           => [ 'required', 'string', 'max:32' ],
+            'processing_activities'                     => [ 'required', 'array', 'min:1' ],
+            'processing_activities.*.purpose'           => [ 'required', 'string' ],
+            'processing_activities.*.legal_basis'       => [ 'required', 'string' ],
+            'processing_activities.*.retention'         => [ 'required', 'string' ],
+            'processing_activities.*.data_categories'   => [ 'required', 'array', 'min:1' ],
+            'processing_activities.*.data_categories.*' => [ 'required', 'string' ],
+            'processing_activities.*.recipients'        => [ 'nullable', 'array' ],
+            'processing_activities.*.recipients.*'      => [ 'string' ],
+        ];
+    }
+}

--- a/src/Http/routes/ai.php
+++ b/src/Http/routes/ai.php
@@ -1,0 +1,30 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * Compliance AI API routes.
+ *
+ * Mounted at `/api/v1/compliance/ai` by ComplianceServiceProvider so
+ * React and Vue front-ends can trigger the three compliance.* AI
+ * agents (privacy policy draft, DPIA assistance, consent text) via
+ * plain HTTP.
+ *
+ * @since 1.1.0
+ */
+
+use ArtisanPackUI\Compliance\Http\Controllers\Ai\AiController;
+use Illuminate\Support\Facades\Route;
+
+// Guard is configurable via `artisanpack.compliance.ai.guard` — defaults
+// to `sanctum` because the parent group is mounted under the `api`
+// middleware stack, but consumer apps without Sanctum can point it at
+// `web` (session auth) or any other configured guard.
+$guard = config( 'artisanpack.compliance.ai.guard', 'sanctum' );
+
+Route::middleware( 'auth:' . $guard )->group( function (): void {
+    Route::get( '/features', [ AiController::class, 'features' ] );
+    Route::post( '/privacy-policy-draft', [ AiController::class, 'privacyPolicyDraft' ] );
+    Route::post( '/dpia-assistance', [ AiController::class, 'dpiaAssistance' ] );
+    Route::post( '/consent-text', [ AiController::class, 'consentText' ] );
+} );

--- a/src/Livewire/Ai/AiTools.php
+++ b/src/Livewire/Ai/AiTools.php
@@ -1,0 +1,258 @@
+<?php
+
+/**
+ * Livewire trigger surface for the compliance AI features.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Compliance
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Livewire\Ai;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\Compliance\Ai\Agents\ConsentTextSuggestionAgent;
+use ArtisanPackUI\Compliance\Ai\Agents\DpiaAssistanceAgent;
+use ArtisanPackUI\Compliance\Ai\Agents\PrivacyPolicyDraftAgent;
+use ArtisanPackUI\Compliance\ComplianceServiceProvider;
+use ArtisanPackUI\Compliance\Models\AiDraft;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Log;
+use Livewire\Attributes\On;
+use Livewire\Component;
+use Throwable;
+
+/**
+ * Thin Livewire wrapper for the compliance high-stakes AI agents.
+ * Emits browser events the host admin surface listens for and folds
+ * into the UI.
+ *
+ * The component is intentionally transport-only — it holds no
+ * persistent state and does not render any UI beyond a marker div.
+ * Hosts render:
+ * 1. The un-dismissable "requires legal review" banner
+ * 2. The acknowledgement checkbox that gates viewing the draft
+ * 3. The "Save as new draft" action, which dispatches a
+ *    `compliance-ai:save-draft` browser event that this component
+ *    persists via {@see AiDraft::create()}. Drafts are append-only —
+ *    every save writes a new row.
+ *
+ * React and Vue front-ends do NOT need this component — they hit the
+ * REST endpoints registered under `/api/v1/compliance/ai/*` directly.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Compliance
+ *
+ * @since      1.1.0
+ */
+class AiTools extends Component
+{
+    /**
+     * Draft a starter privacy policy.
+     *
+     * @param  array<string, mixed>  $payload  Agent input (see PrivacyPolicyDraftAgent docblock).
+     */
+    #[On( 'compliance-ai:draft-privacy-policy' )]
+    public function draftPrivacyPolicy( array $payload ): void
+    {
+        $this->run(
+            'compliance.privacy_policy_draft',
+            fn () => PrivacyPolicyDraftAgent::for( $payload )->run(),
+        );
+    }
+
+    /**
+     * Draft a DPIA.
+     *
+     * @param  array<string, mixed>  $payload  Agent input (see DpiaAssistanceAgent docblock).
+     */
+    #[On( 'compliance-ai:draft-dpia' )]
+    public function draftDpia( array $payload ): void
+    {
+        $this->run(
+            'compliance.dpia_assistance',
+            fn () => DpiaAssistanceAgent::for( $payload )->run(),
+        );
+    }
+
+    /**
+     * Suggest consent text.
+     *
+     * @param  array<string, mixed>  $payload  Agent input (see ConsentTextSuggestionAgent docblock).
+     */
+    #[On( 'compliance-ai:suggest-consent-text' )]
+    public function suggestConsentText( array $payload ): void
+    {
+        $this->run(
+            'compliance.consent_text',
+            fn () => ConsentTextSuggestionAgent::for( $payload )->run(),
+        );
+    }
+
+    /**
+     * Persist an AI-generated draft.
+     *
+     * Append-only: every call creates a new row. The database model
+     * throws if anything tries to update an existing draft — the host
+     * legal-review workflow depends on the version history being
+     * immutable.
+     *
+     * `metadata.acknowledged` MUST be true — the host is asserting the
+     * reviewer checked the "requires legal review" acknowledgement
+     * checkbox before saving.
+     *
+     * @param  string               $featureKey  Feature key that produced the draft.
+     * @param  array<string, mixed> $output      Agent output body (the `output` value from a successful run).
+     * @param  string|null          $subjectKey  Optional grouping key for related drafts (e.g. document slug).
+     * @param  array<string, mixed> $metadata    Free-form metadata; must include `acknowledged => true`.
+     */
+    #[On( 'compliance-ai:save-draft' )]
+    public function saveDraft(
+        string $featureKey,
+        array $output,
+        ?string $subjectKey = null,
+        array $metadata = [],
+    ): void {
+        if ( ! in_array( $featureKey, ComplianceServiceProvider::AI_FEATURE_KEYS, true ) ) {
+            $this->dispatch(
+                'compliance-ai:save-draft:rejected',
+                feature: $featureKey,
+                message: 'Unknown compliance AI feature key.',
+            );
+            return;
+        }
+
+        if ( ! Gate::allows( 'manageComplianceAiDrafts' ) ) {
+            $this->dispatch(
+                'compliance-ai:save-draft:rejected',
+                feature: $featureKey,
+                message: 'You are not authorized to save compliance AI drafts.',
+            );
+            return;
+        }
+
+        /** @var FeatureRegistry $registry */
+        $registry = app( FeatureRegistry::class );
+
+        if ( null === $registry->get( $featureKey ) || ! $registry->isToggleOn( $featureKey ) ) {
+            $this->dispatch(
+                'compliance-ai:save-draft:rejected',
+                feature: $featureKey,
+                message: 'This compliance AI feature is currently disabled.',
+            );
+            return;
+        }
+
+        if ( true !== ( $metadata['acknowledged'] ?? false ) ) {
+            $this->dispatch(
+                'compliance-ai:save-draft:rejected',
+                feature: $featureKey,
+                message: 'Legal-review acknowledgement is required before a draft can be saved.',
+            );
+            return;
+        }
+
+        try {
+            $draft = AiDraft::create( [
+                'feature_key' => $featureKey,
+                'subject_key' => $subjectKey,
+                'content'     => $output,
+                'metadata'    => $metadata,
+                'created_by'  => auth()->id(),
+            ] );
+
+            $this->dispatch(
+                'compliance-ai:save-draft:success',
+                feature: $featureKey,
+                draft_id: $draft->id,
+            );
+        } catch ( Throwable $e ) {
+            Log::error( 'compliance AI draft save failed', [
+                'feature' => $featureKey,
+                'error'   => $e->getMessage(),
+            ] );
+
+            $this->dispatch(
+                'compliance-ai:save-draft:error',
+                feature: $featureKey,
+                message: 'Unexpected error saving draft.',
+            );
+        }
+    }
+
+    /**
+     * Return the enabled state of the three compliance.* features.
+     *
+     * @return array<string, bool>
+     */
+    public function enabledFeatures(): array
+    {
+        /** @var FeatureRegistry $registry */
+        $registry = app( FeatureRegistry::class );
+
+        $state = [];
+        foreach ( ComplianceServiceProvider::AI_FEATURE_KEYS as $key ) {
+            $state[ $key ] = null !== $registry->get( $key ) && $registry->isToggleOn( $key );
+        }
+        return $state;
+    }
+
+    /**
+     * Marker div only — this is a transport component, not a UI.
+     */
+    public function render(): string
+    {
+        return '<div class="ap-compliance-ai-tools" data-testid="ap-compliance-ai-tools"></div>';
+    }
+
+    /**
+     * Shared agent-run path.
+     */
+    private function run( string $featureKey, callable $callback ): void
+    {
+        try {
+            $output = $callback();
+
+            $this->dispatch(
+                sprintf( 'compliance-ai:%s:success', $featureKey ),
+                feature: $featureKey,
+                output: $output,
+            );
+        } catch ( FeatureDisabledException $e ) {
+            $this->dispatch(
+                sprintf( 'compliance-ai:%s:disabled', $featureKey ),
+                feature: $featureKey,
+                message: $e->getMessage(),
+            );
+        } catch ( MissingCredentialsException $e ) {
+            $this->dispatch(
+                sprintf( 'compliance-ai:%s:missing-credentials', $featureKey ),
+                feature: $featureKey,
+                message: $e->getMessage(),
+            );
+        } catch ( FeatureError $e ) {
+            $this->dispatch(
+                sprintf( 'compliance-ai:%s:invalid-input', $featureKey ),
+                feature: $featureKey,
+                message: $e->getMessage(),
+            );
+        } catch ( Throwable $e ) {
+            Log::error( 'compliance AI trigger failed', [
+                'feature' => $featureKey,
+                'error'   => $e->getMessage(),
+            ] );
+
+            $this->dispatch(
+                sprintf( 'compliance-ai:%s:error', $featureKey ),
+                feature: $featureKey,
+                message: 'Unexpected error running AI feature.',
+            );
+        }
+    }
+}

--- a/src/Models/AiDraft.php
+++ b/src/Models/AiDraft.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * AI-generated compliance draft — append-only versioned store for
+ * privacy-policy, DPIA, and consent-text outputs.
+ *
+ * Drafts are NEVER updated. Every agent run creates a new row so the
+ * revision history is preserved and legal reviewers can compare
+ * versions. Enforced at the model level via {@see UPDATED_AT} being
+ * `null` and the {@see saving()} guard in the boot method.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Compliance
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Compliance\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use RuntimeException;
+
+class AiDraft extends Model
+{
+    public const UPDATED_AT = null;
+
+    protected $table = 'compliance_ai_drafts';
+
+    protected $fillable = [
+        'feature_key',
+        'subject_key',
+        'content',
+        'metadata',
+        'created_by',
+    ];
+
+    public function scopeForFeature( Builder $query, string $featureKey ): Builder
+    {
+        return $query->where( 'feature_key', $featureKey );
+    }
+
+    public function scopeForSubject( Builder $query, string $subjectKey ): Builder
+    {
+        return $query->where( 'subject_key', $subjectKey );
+    }
+
+    protected static function booted(): void
+    {
+        static::updating( function ( AiDraft $draft ): void {
+            throw new RuntimeException(
+                'Compliance AI drafts are append-only. Create a new draft instead of updating draft #' . $draft->id . '.',
+            );
+        } );
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'content'    => 'array',
+            'metadata'   => 'array',
+            'created_at' => 'datetime',
+        ];
+    }
+}

--- a/tests/Feature/Ai/AiAgentTestSetup.php
+++ b/tests/Feature/Ai/AiAgentTestSetup.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Shared bootstrap for compliance AI agent tests.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Compliance
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace Tests\Feature\Ai;
+
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Contracts\CredentialResolver;
+use ArtisanPackUI\Ai\Credentials\ChainedCredentialResolver;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Compliance\ComplianceServiceProvider;
+use Tests\Support\FakeAgentPrompter;
+
+/**
+ * Registers a fake prompter, stub credentials, and enables the three
+ * feature toggles the compliance AI surface cares about.
+ */
+final class AiAgentTestSetup
+{
+    /**
+     * @param  \Illuminate\Foundation\Application  $app
+     */
+    public static function bootstrap( $app ): FakeAgentPrompter
+    {
+        /** @var ChainedCredentialResolver $resolver */
+        $resolver = $app->make( CredentialResolver::class );
+        $resolver->setOverride(
+            new Credentials( provider: 'anthropic', apiKey: 'sk-test', defaultModel: 'claude-haiku-4-5' ),
+        );
+        $resolver->useStore( fn () => null );
+
+        $prompter = new FakeAgentPrompter();
+        $app->instance( AgentPrompter::class, $prompter );
+
+        foreach ( ComplianceServiceProvider::AI_FEATURE_KEYS as $key ) {
+            $app['config']->set( "artisanpack.ai.features.{$key}.enabled", true );
+        }
+
+        return $prompter;
+    }
+}

--- a/tests/Feature/Ai/AiDraftAppendOnlyTest.php
+++ b/tests/Feature/Ai/AiDraftAppendOnlyTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Tests\Feature\Ai;
+
+use ArtisanPackUI\Compliance\Models\AiDraft;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use RuntimeException;
+
+uses( RefreshDatabase::class );
+
+it( 'stores drafts with correct feature key and content payload', function (): void {
+    $draft = AiDraft::create( [
+        'feature_key' => 'compliance.privacy_policy_draft',
+        'subject_key' => 'main-site',
+        'content'     => [ 'policy_markdown' => '# Hello' ],
+        'metadata'    => [ 'acknowledged' => true ],
+    ] );
+
+    expect( $draft->exists )->toBeTrue();
+    expect( $draft->fresh()->content )->toBe( [ 'policy_markdown' => '# Hello' ] );
+} );
+
+it( 'blocks updates to existing drafts to preserve version history', function (): void {
+    $draft = AiDraft::create( [
+        'feature_key' => 'compliance.privacy_policy_draft',
+        'content'     => [ 'policy_markdown' => '# Original' ],
+    ] );
+
+    $draft->content = [ 'policy_markdown' => '# Modified' ];
+
+    expect( fn () => $draft->save() )->toThrow( RuntimeException::class );
+
+    // Confirm nothing was persisted.
+    expect( $draft->fresh()->content )->toBe( [ 'policy_markdown' => '# Original' ] );
+} );
+
+it( 'allows multiple drafts per subject to accumulate as versions', function (): void {
+    AiDraft::create( [
+        'feature_key' => 'compliance.privacy_policy_draft',
+        'subject_key' => 'main-site',
+        'content'     => [ 'v' => 1 ],
+    ] );
+    AiDraft::create( [
+        'feature_key' => 'compliance.privacy_policy_draft',
+        'subject_key' => 'main-site',
+        'content'     => [ 'v' => 2 ],
+    ] );
+
+    $count = AiDraft::query()
+        ->forFeature( 'compliance.privacy_policy_draft' )
+        ->forSubject( 'main-site' )
+        ->count();
+
+    expect( $count )->toBe( 2 );
+} );

--- a/tests/Feature/Ai/AiToolsSaveDraftTest.php
+++ b/tests/Feature/Ai/AiToolsSaveDraftTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Tests\Feature\Ai;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Compliance\Livewire\Ai\AiTools;
+use ArtisanPackUI\Compliance\Models\AiDraft;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Livewire;
+
+uses( RefreshDatabase::class );
+
+beforeEach( function (): void {
+    AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+function validDraftPayload(): array
+{
+    return [
+        'featureKey' => 'compliance.privacy_policy_draft',
+        'output'     => [ 'policy_markdown' => '# hi', 'requires_legal_review' => true ],
+        'subjectKey' => 'main-site',
+        'metadata'   => [ 'acknowledged' => true ],
+    ];
+}
+
+it( 'rejects saves when the manageComplianceAiDrafts gate denies', function (): void {
+    // Default-deny gate is registered; no override → denied.
+    Livewire::test( AiTools::class )
+        ->dispatch( 'compliance-ai:save-draft', ...validDraftPayload() )
+        ->assertDispatched( 'compliance-ai:save-draft:rejected' );
+
+    expect( AiDraft::count() )->toBe( 0 );
+} );
+
+it( 'rejects saves when the feature is toggled off', function (): void {
+    Gate::define( 'manageComplianceAiDrafts', fn ( $user = null ) => true );
+
+    // Turn the feature OFF at the registry (config path uses literal dotted
+    // keys the registry cannot address via config()->set — go through the
+    // registry API instead).
+    app( FeatureRegistry::class )->disable( 'compliance.privacy_policy_draft' );
+
+    Livewire::test( AiTools::class )
+        ->dispatch( 'compliance-ai:save-draft', ...validDraftPayload() )
+        ->assertDispatched( 'compliance-ai:save-draft:rejected' );
+
+    expect( AiDraft::count() )->toBe( 0 );
+} );
+
+it( 'rejects saves without the legal-review acknowledgement', function (): void {
+    Gate::define( 'manageComplianceAiDrafts', fn ( $user = null ) => true );
+
+    $payload             = validDraftPayload();
+    $payload['metadata'] = []; // no acknowledged flag
+
+    Livewire::test( AiTools::class )
+        ->dispatch( 'compliance-ai:save-draft', ...$payload )
+        ->assertDispatched( 'compliance-ai:save-draft:rejected' );
+
+    expect( AiDraft::count() )->toBe( 0 );
+} );
+
+it( 'persists when gate + toggle + acknowledgement all pass', function (): void {
+    Gate::define( 'manageComplianceAiDrafts', fn ( $user = null ) => true );
+
+    Livewire::test( AiTools::class )
+        ->dispatch( 'compliance-ai:save-draft', ...validDraftPayload() )
+        ->assertDispatched( 'compliance-ai:save-draft:success' );
+
+    expect( AiDraft::count() )->toBe( 1 );
+} );

--- a/tests/Feature/Ai/ConsentTextSuggestionAgentTest.php
+++ b/tests/Feature/Ai/ConsentTextSuggestionAgentTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Tests\Feature\Ai;
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Compliance\Ai\Agents\ConsentTextSuggestionAgent;
+
+beforeEach( function (): void {
+    $this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+function validConsentInput(): array
+{
+    return [
+        'purpose'         => 'Send weekly product-update emails',
+        'audience'        => 'general public',
+        'jurisdiction'    => 'EU',
+        'data_categories' => [ 'email address', 'engagement metrics' ],
+    ];
+}
+
+it( 'forces requires_legal_review and truncates over-length text', function (): void {
+    $longText = str_repeat( 'x', 900 );
+    $this->prompter->queue( [
+        'consent_text'          => $longText,
+        'short_label'           => 'I agree.',
+        'reading_level'         => [ 'grade' => 8.0, 'score' => 70.0 ],
+        'jurisdiction_notes'    => [ 'Confirm GDPR opt-in wording.' ],
+        'requires_legal_review' => false, // model lying
+    ] );
+
+    $result = ConsentTextSuggestionAgent::for( validConsentInput() )->run();
+
+    expect( $result['requires_legal_review'] )->toBeTrue();
+    expect( mb_strlen( $result['consent_text'] ) )->toBe( 800 );
+} );
+
+it( 'truncates over-length short_label', function (): void {
+    $this->prompter->queue( [
+        'consent_text'          => 'ok',
+        'short_label'           => str_repeat( 'y', 100 ),
+        'reading_level'         => [ 'grade' => 8.0, 'score' => 70.0 ],
+        'jurisdiction_notes'    => [ 'x' ],
+        'requires_legal_review' => true,
+    ] );
+
+    $result = ConsentTextSuggestionAgent::for( validConsentInput() )->run();
+
+    expect( mb_strlen( $result['short_label'] ) )->toBe( 80 );
+} );
+
+it( 'raises FeatureError on empty short_label to avoid unlabelled consent checkbox', function (): void {
+    $this->prompter->queue( [
+        'consent_text'          => 'A perfectly good consent paragraph.',
+        'short_label'           => '',
+        'reading_level'         => [ 'grade' => 8.0, 'score' => 70.0 ],
+        'jurisdiction_notes'    => [ 'x' ],
+        'requires_legal_review' => true,
+    ] );
+
+    expect( fn () => ConsentTextSuggestionAgent::for( validConsentInput() )->run() )
+        ->toThrow( FeatureError::class );
+} );
+
+it( 'raises FeatureError on empty consent text', function (): void {
+    $this->prompter->queue( [
+        'consent_text'          => '',
+        'short_label'           => '',
+        'reading_level'         => [ 'grade' => 8.0, 'score' => 70.0 ],
+        'jurisdiction_notes'    => [ 'x' ],
+        'requires_legal_review' => true,
+    ] );
+
+    expect( fn () => ConsentTextSuggestionAgent::for( validConsentInput() )->run() )
+        ->toThrow( FeatureError::class );
+} );
+
+it( 'backfills jurisdiction_notes when the model omits them', function (): void {
+    $this->prompter->queue( [
+        'consent_text'          => 'ok',
+        'short_label'           => 'I agree.',
+        'reading_level'         => [ 'grade' => 8.0, 'score' => 70.0 ],
+        'jurisdiction_notes'    => [],
+        'requires_legal_review' => true,
+    ] );
+
+    $result = ConsentTextSuggestionAgent::for( validConsentInput() )->run();
+
+    expect( $result['jurisdiction_notes'] )->not->toBeEmpty();
+} );
+
+it( 'validates required input fields', function (): void {
+    $input = validConsentInput();
+    unset( $input['jurisdiction'] );
+    expect( fn () => ConsentTextSuggestionAgent::for( $input )->run() )
+        ->toThrow( FeatureError::class );
+
+    $input                    = validConsentInput();
+    $input['data_categories'] = [];
+    expect( fn () => ConsentTextSuggestionAgent::for( $input )->run() )
+        ->toThrow( FeatureError::class );
+} );
+
+it( 'clamps target_reading_level to the allowed range', function (): void {
+    $this->prompter->queue( [
+        'consent_text'          => 'ok',
+        'short_label'           => 'I agree.',
+        'reading_level'         => [ 'grade' => 8.0, 'score' => 70.0 ],
+        'jurisdiction_notes'    => [ 'x' ],
+        'requires_legal_review' => true,
+    ] );
+
+    ConsentTextSuggestionAgent::for( array_merge( validConsentInput(), [
+        'target_reading_level' => 200, // out of range — silently ignored
+    ] ) )->run();
+
+    $sentInstruction = collect( $this->prompter->calls[0]['message'] )->pluck( 'text' )->implode( "\n" );
+    expect( $sentInstruction )->toContain( 'Target grade level: 8' );
+} );

--- a/tests/Feature/Ai/DpiaAssistanceAgentTest.php
+++ b/tests/Feature/Ai/DpiaAssistanceAgentTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Tests\Feature\Ai;
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Compliance\Ai\Agents\DpiaAssistanceAgent;
+
+beforeEach( function (): void {
+    $this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+function validDpiaInput(): array
+{
+    return [
+        'activity_name'    => 'Employee performance analytics',
+        'activity_purpose' => 'Track productivity metrics for annual reviews',
+        'processing_scale' => 'medium',
+        'data_categories'  => [ 'name', 'performance metrics', 'schedule data' ],
+        'data_subjects'    => [ 'employees' ],
+    ];
+}
+
+it( 'forces requires_legal_review and returns risks', function (): void {
+    $this->prompter->queue( [
+        'risks' => [
+            [
+                'title'             => 'Function creep',
+                'description'       => 'Metrics may be repurposed for termination decisions.',
+                'likelihood'        => 'medium',
+                'severity'          => 'high',
+                'affected_subjects' => [ 'employees' ],
+            ],
+        ],
+        'mitigations' => [
+            [
+                'risk_title'    => 'Function creep',
+                'mitigation'    => 'Restrict data use to review process via role-based access.',
+                'residual_risk' => 'low',
+            ],
+        ],
+        'stakeholder_impacts'   => [],
+        'requires_legal_review' => false, // model lying
+        'review_checklist'      => [ 'Confirm mitigations are enforced technically.' ],
+    ] );
+
+    $result = DpiaAssistanceAgent::for( validDpiaInput() )->run();
+
+    expect( $result['requires_legal_review'] )->toBeTrue();
+    expect( $result['risks'] )->toHaveCount( 1 );
+    expect( $result['mitigations'][0]['risk_title'] )->toBe( 'Function creep' );
+} );
+
+it( 'backfills a review checklist when the model omits one', function (): void {
+    $this->prompter->queue( [
+        'risks' => [
+            [
+                'title'             => 'x',
+                'description'       => 'y',
+                'likelihood'        => 'low',
+                'severity'          => 'low',
+                'affected_subjects' => [ 'z' ],
+            ],
+        ],
+        'mitigations'           => [
+            [ 'risk_title' => 'x', 'mitigation' => 'a', 'residual_risk' => 'low' ],
+        ],
+        'stakeholder_impacts'   => [],
+        'requires_legal_review' => true,
+        'review_checklist'      => [],
+    ] );
+
+    $result = DpiaAssistanceAgent::for( validDpiaInput() )->run();
+
+    expect( $result['review_checklist'] )->not->toBeEmpty();
+    expect( $result['review_checklist'][0] )->toContain( 'DPO' );
+} );
+
+it( 'rejects risks that have no matching mitigation entry', function (): void {
+    $this->prompter->queue( [
+        'risks' => [
+            [
+                'title'             => 'Cross-border transfer without SCC',
+                'description'       => '...',
+                'likelihood'        => 'high',
+                'severity'          => 'high',
+                'affected_subjects' => [ 'employees' ],
+            ],
+        ],
+        'mitigations'           => [], // linkage broken
+        'stakeholder_impacts'   => [],
+        'requires_legal_review' => true,
+        'review_checklist'      => [ 'x' ],
+    ] );
+
+    expect( fn () => DpiaAssistanceAgent::for( validDpiaInput() )->run() )
+        ->toThrow( FeatureError::class );
+} );
+
+it( 'rejects when a mitigation refers to a risk_title that does not exist', function (): void {
+    $this->prompter->queue( [
+        'risks' => [
+            [
+                'title'             => 'Real risk',
+                'description'       => '...',
+                'likelihood'        => 'medium',
+                'severity'          => 'high',
+                'affected_subjects' => [ 'employees' ],
+            ],
+        ],
+        'mitigations' => [
+            [ 'risk_title' => 'A different risk', 'mitigation' => '...', 'residual_risk' => 'low' ],
+        ],
+        'stakeholder_impacts'   => [],
+        'requires_legal_review' => true,
+        'review_checklist'      => [ 'x' ],
+    ] );
+
+    expect( fn () => DpiaAssistanceAgent::for( validDpiaInput() )->run() )
+        ->toThrow( FeatureError::class );
+} );
+
+it( 'raises FeatureError when no risks are returned', function (): void {
+    $this->prompter->queue( [
+        'risks'                 => [],
+        'mitigations'           => [],
+        'stakeholder_impacts'   => [],
+        'requires_legal_review' => true,
+        'review_checklist'      => [ 'x' ],
+    ] );
+
+    expect( fn () => DpiaAssistanceAgent::for( validDpiaInput() )->run() )
+        ->toThrow( FeatureError::class );
+} );
+
+it( 'validates required input fields', function (): void {
+    $input = validDpiaInput();
+    unset( $input['data_categories'] );
+    expect( fn () => DpiaAssistanceAgent::for( $input )->run() )
+        ->toThrow( FeatureError::class );
+
+    $input                  = validDpiaInput();
+    $input['data_subjects'] = [];
+    expect( fn () => DpiaAssistanceAgent::for( $input )->run() )
+        ->toThrow( FeatureError::class );
+} );

--- a/tests/Feature/Ai/FeatureRegistrationTest.php
+++ b/tests/Feature/Ai/FeatureRegistrationTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Tests\Feature\Ai;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Compliance\Ai\Agents\ConsentTextSuggestionAgent;
+use ArtisanPackUI\Compliance\Ai\Agents\DpiaAssistanceAgent;
+use ArtisanPackUI\Compliance\Ai\Agents\PrivacyPolicyDraftAgent;
+use ArtisanPackUI\Compliance\ComplianceServiceProvider;
+
+it( 'declares three compliance.* features from the service provider', function (): void {
+    $provider = new ComplianceServiceProvider( $this->app );
+    $features = $provider->aiFeatures();
+
+    expect( $features )->toHaveKeys( [
+        'compliance.privacy_policy_draft',
+        'compliance.dpia_assistance',
+        'compliance.consent_text',
+    ] );
+
+    expect( $features['compliance.privacy_policy_draft']['agent'] )->toBe( PrivacyPolicyDraftAgent::class );
+    expect( $features['compliance.dpia_assistance']['agent'] )->toBe( DpiaAssistanceAgent::class );
+    expect( $features['compliance.consent_text']['agent'] )->toBe( ConsentTextSuggestionAgent::class );
+
+    foreach ( $features as $definition ) {
+        expect( $definition['package'] )->toBe( 'artisanpack-ui/compliance' );
+    }
+} );
+
+it( 'registers the three features with the FeatureRegistry at boot', function (): void {
+    /** @var FeatureRegistry $registry */
+    $registry = $this->app->make( FeatureRegistry::class );
+
+    foreach ( ComplianceServiceProvider::AI_FEATURE_KEYS as $key ) {
+        expect( $registry->get( $key ) )->not->toBeNull();
+    }
+} );

--- a/tests/Feature/Ai/PrivacyPolicyDraftAgentTest.php
+++ b/tests/Feature/Ai/PrivacyPolicyDraftAgentTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace Tests\Feature\Ai;
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Compliance\Ai\Agents\PrivacyPolicyDraftAgent;
+
+beforeEach( function (): void {
+    $this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+function validPolicyInput(): array
+{
+    return [
+        'organization_name'     => 'Acme Widgets',
+        'contact_email'         => 'privacy@acme.example',
+        'effective_date'        => '2026-08-01',
+        'jurisdictions'         => [ 'EU', 'US-CA' ],
+        'processing_activities' => [
+            [
+                'purpose'         => 'Order fulfillment',
+                'data_categories' => [ 'name', 'address' ],
+                'legal_basis'     => 'contract',
+                'retention'       => '5 years',
+            ],
+        ],
+    ];
+}
+
+it( 'always forces requires_legal_review to true', function (): void {
+    $this->prompter->queue( [
+        'policy_markdown'       => '# Privacy Policy',
+        'section_headings'      => [ 'What we collect' ],
+        'requires_legal_review' => false, // model lying — validator must overwrite
+        'review_checklist'      => [ 'Verify retention.' ],
+        'jurisdiction_notes'    => [ 'EU' => 'GDPR applies.' ],
+    ] );
+
+    $result = PrivacyPolicyDraftAgent::for( validPolicyInput() )->run();
+
+    expect( $result['requires_legal_review'] )->toBeTrue();
+} );
+
+it( 'backfills a review checklist when the model omits one', function (): void {
+    $this->prompter->queue( [
+        'policy_markdown'       => '# Privacy Policy',
+        'section_headings'      => [],
+        'requires_legal_review' => true,
+        'review_checklist'      => [], // empty — validator must supply a default
+        'jurisdiction_notes'    => [],
+    ] );
+
+    $result = PrivacyPolicyDraftAgent::for( validPolicyInput() )->run();
+
+    expect( $result['review_checklist'] )->not->toBeEmpty();
+    expect( $result['review_checklist'][0] )->toContain( 'legal counsel' );
+} );
+
+it( 'raises FeatureError on an empty policy body', function (): void {
+    $this->prompter->queue( [
+        'policy_markdown'       => '',
+        'section_headings'      => [],
+        'requires_legal_review' => true,
+        'review_checklist'      => [ 'x' ],
+        'jurisdiction_notes'    => [],
+    ] );
+
+    expect( fn () => PrivacyPolicyDraftAgent::for( validPolicyInput() )->run() )
+        ->toThrow( FeatureError::class );
+} );
+
+it( 'validates required input fields', function (): void {
+    expect( fn () => PrivacyPolicyDraftAgent::for( 'not-an-array' )->run() )
+        ->toThrow( FeatureError::class );
+
+    $input = validPolicyInput();
+    unset( $input['organization_name'] );
+    expect( fn () => PrivacyPolicyDraftAgent::for( $input )->run() )
+        ->toThrow( FeatureError::class );
+
+    $input                  = validPolicyInput();
+    $input['contact_email'] = 'not-an-email';
+    expect( fn () => PrivacyPolicyDraftAgent::for( $input )->run() )
+        ->toThrow( FeatureError::class );
+
+    $input                   = validPolicyInput();
+    $input['effective_date'] = '08/01/2026';
+    expect( fn () => PrivacyPolicyDraftAgent::for( $input )->run() )
+        ->toThrow( FeatureError::class );
+
+    $input                          = validPolicyInput();
+    $input['processing_activities'] = [];
+    expect( fn () => PrivacyPolicyDraftAgent::for( $input )->run() )
+        ->toThrow( FeatureError::class );
+} );
+
+it( 'rejects processing_activities items that are not objects', function (): void {
+    $input                          = validPolicyInput();
+    $input['processing_activities'] = [
+        'purpose only string',
+        [
+            'purpose'         => 'Order fulfillment',
+            'data_categories' => [ 'name' ],
+            'legal_basis'     => 'contract',
+            'retention'       => '5 years',
+        ],
+    ];
+
+    expect( fn () => PrivacyPolicyDraftAgent::for( $input )->run() )
+        ->toThrow( FeatureError::class );
+} );

--- a/tests/Support/FakeAgentPrompter.php
+++ b/tests/Support/FakeAgentPrompter.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Test fake for the AgentPrompter contract.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Compliance
+ *
+ * @since      1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace Tests\Support;
+
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+
+/**
+ * Records every prompter call and returns queued responses in FIFO
+ * order. Mirrors the fakes shipped by cms-framework and the ai
+ * package's own suite.
+ */
+final class FakeAgentPrompter implements AgentPrompter
+{
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    public array $calls = [];
+
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    private array $queue = [];
+
+    /**
+     * @param  array<string, mixed>  $output
+     */
+    public function queue( array $output, int $inputTokens = 100, int $outputTokens = 50 ): void
+    {
+        $this->queue[] = [
+            'output'        => $output,
+            'input_tokens'  => $inputTokens,
+            'output_tokens' => $outputTokens,
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function prompt(
+        Credentials $credentials,
+        string $model,
+        string $instructions,
+        string|array $message,
+        array $outputSchema,
+    ): array {
+        $this->calls[] = [
+            'credentials'   => $credentials,
+            'model'         => $model,
+            'instructions'  => $instructions,
+            'message'       => $message,
+            'output_schema' => $outputSchema,
+        ];
+
+        if ( [] === $this->queue ) {
+            return [
+                'output'        => [],
+                'input_tokens'  => 0,
+                'output_tokens' => 0,
+            ];
+        }
+
+        return array_shift( $this->queue );
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,7 +4,9 @@ declare( strict_types=1 );
 
 namespace Tests;
 
+use ArtisanPackUI\Ai\AiServiceProvider;
 use ArtisanPackUI\Compliance\ComplianceServiceProvider;
+use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 
 /**
@@ -36,6 +38,8 @@ abstract class TestCase extends BaseTestCase
     protected function getPackageProviders( $app ): array
     {
         return [
+            AiServiceProvider::class,
+            LivewireServiceProvider::class,
             ComplianceServiceProvider::class,
         ];
     }


### PR DESCRIPTION
<!--- Title format: Release v1.0.0 -->


## Release Information

- **Release Version:** v1.1.0
- **Release Date:** 2026-07-09
- **Release Type:** Minor
- **Release Branch:** `release/1.1.0`
- **Target Branch:** `main`

## Release Summary

Ships the high-stakes compliance AI trigger surface: three agents (`PrivacyPolicyDraftAgent`, `DpiaAssistanceAgent`, `ConsentTextSuggestionAgent`) backed by `artisanpack-ui/ai`, with structural legal-review guardrails at three layers (output shape, Livewire save gate, append-only persistence). Also drops PHP 8.2 support because the AI dependency requires PHP 8.3+.

## Changelog

### Added

- **AI integration** — three high-stakes agents powered by `artisanpack-ui/ai` (soft dependency): `compliance.privacy_policy_draft` (Opus 4.7), `compliance.dpia_assistance` (Opus 4.7), `compliance.consent_text` (Sonnet 4.6).
- **Guardrail contract** — every agent forces `requires_legal_review: true` and a non-empty `review_checklist` on its output; hosts are required to render an un-dismissable "requires legal review" banner and gate viewing the body behind an acknowledgement checkbox.
- **Append-only draft storage** — new `compliance_ai_drafts` table + `AiDraft` model preserve every generation as a new row; UPDATE attempts throw at the ORM layer.
- **Trigger surfaces** — Livewire component `ap-compliance-ai-tools` for Blade/Livewire hosts plus `/api/v1/compliance/ai/*` REST endpoints for React and Vue hosts. Both are skipped when `artisanpack-ui/ai` is not installed.

### Changed

- **PHP 8.2 support dropped** — minimum PHP is now 8.3. The AI features depend on `artisanpack-ui/ai`, which requires PHP 8.3+. Apps still on PHP 8.2 should stay on `1.0.x`.

### Fixed

- **Feature-toggle bypass on save** — `AiTools::saveDraft` now rejects saves when the feature is toggled OFF in the FeatureRegistry.
- **DPIA risk↔mitigation linkage** — `DpiaAssistanceAgent::validateOutput` now enforces that every enumerated risk has a matching mitigation entry.
- **Privacy-policy input validation** — `PrivacyPolicyDraftAgent` now rejects non-array elements in `processing_activities`, closing a Livewire-only path that could send mixed lists to the prompter.
- **Consent-text short label** — `ConsentTextSuggestionAgent` now throws `FeatureError` when the model returns an empty `short_label`.

### Security

- **Authorization gate on draft persistence** — `AiTools::saveDraft` now checks a `manageComplianceAiDrafts` Gate (default-deny) before writing.
- **Configurable auth guard** — the `/api/v1/compliance/ai/*` REST routes now read the guard from `config('artisanpack.compliance.ai.guard')` (default `sanctum`, override via `COMPLIANCE_AI_GUARD`).

## Issues and Pull Requests

**Issues Fixed:**
- Closes #18 — PrivacyPolicyDraftAgent
- Closes #19 — DpiaAssistanceAgent
- Closes #20 — ConsentTextSuggestionAgent

**Related PRs:**
- #23 — AI integration feature PR (merged into `release/1.1`)

**Deferred to follow-ups:**
- #21 — Introduce `ComplianceHighStakesAgent` base class to make guardrails structural
- #22 — Wrap AI trigger surface user-facing strings in `__()` for i18n

## Breaking Changes

- [ ] No breaking changes
- [x] Breaking changes documented below

**Breaking changes:**

- **Minimum PHP is now 8.3.** Apps on PHP 8.2 must stay on the `1.0.x` line — `composer require artisanpack-ui/compliance:^1.0` will keep them on 1.0.x, or pin to `~1.0.1` explicitly.

**Migration guide:**

For most apps this is a no-op. For any app currently on PHP 8.2 that wants 1.1.0's AI features, upgrade PHP to 8.3+ before bumping the compliance constraint. Apps that don't need the AI features can stay on `1.0.x` indefinitely.

## Testing Checklist

- [x] All automated tests passing — 41 tests, 81 assertions
- [x] Manual testing completed — verified via dev-app `/ai-issues-test/compliance-issue-{18,19,20}` surfaces in fake + real-provider modes
- [ ] Accessibility tests passing — n/a for this package (backend)
- [ ] Performance tests passing — n/a
- [x] Security scan completed — 3 low-severity symfony/yaml advisories on a transitive dev dep (non-blocking)
- [ ] Tested in staging environment — pending consumer-app smoke test post-merge
- [x] Database migrations tested — the new `compliance_ai_drafts` migration is covered by `AiDraftAppendOnlyTest`

**Testing notes:**

The high-stakes UX flow (banner + ack checkbox + reveal) was exercised in the dev-app test surfaces. The append-only guarantee, the three save-draft rejection paths (unknown key, gate deny, missing acknowledgement, toggle off), and the three output-invariant paths (`requires_legal_review` coercion, checklist backfill, empty-body rejection) are all covered by Pest tests.

## Documentation Checklist

- [x] CHANGELOG updated
- [x] README updated
- [x] API documentation updated — new AI features section in `docs/usage.md`, customization notes in `docs/advanced.md`, install-time notes in `docs/installation.md`
- [x] Migration guide written — see Breaking Changes above
- [x] Release notes written — this PR body doubles as the release notes
- [ ] Wiki updated (if applicable) — n/a

## Pre-Release Checklist

- [x] Version number updated in all necessary files — `composer.json` bumped to `1.1.0`
- [ ] Git tag prepared: `v1.1.0` — will be created on merge
- [x] Release branch created/updated: `release/1.1.0`
- [x] Dependencies updated and tested — `composer.lock` synced
- [ ] Build artifacts generated — n/a for a library
- [ ] Deployment plan reviewed — n/a for a library
- [ ] Rollback plan prepared — Composer `~1.0.1` pin
- [ ] Stakeholders notified — n/a

## Deployment

**Deployment steps:**

1. Merge this PR into `main`.
2. Tag `v1.1.0` on the merge commit.
3. Packagist auto-picks up the new tag via the GitHub webhook.

**Rollback plan:**

1. Consumers pin `artisanpack-ui/compliance: "~1.0.1"` to stay on the previous line.
2. If a bug ships in 1.1.0 that requires a hotfix, cut `release/1.1.1` from `main` and follow the same release-prep flow.

### Configuration changes

- New optional `artisanpack.compliance.ai.guard` config key (defaults to `sanctum`).

### Environment variables

- New optional `COMPLIANCE_AI_GUARD` env var (overrides the guard used on the AI REST routes).

## Post-Release Tasks

- [ ] Tag created: `v1.1.0`
- [ ] Release notes published
- [ ] Documentation deployed
- [ ] Announcement sent
- [ ] Monitoring verified
- [ ] Previous version support documented — `1.0.x` is the PHP-8.2 line going forward

## Notes

`composer audit` reports 3 low-severity CVEs in `symfony/yaml` (a transitive dev dependency via Testbench). Not blocking — dev-only surface. Track separately if needed.

Follow-up issues #21 and #22 capture two review findings that were deemed non-blocking for release: a `ComplianceHighStakesAgent` base-class refactor to make the legal-review guardrails structural rather than per-agent, and the i18n sweep to wrap user-facing strings in `__()`. Both are `Awaiting Review` triage with Medium effort / Medium priority.

---

**Release Manager:** @ViewFromTheBox

🤖 Generated with [Claude Code](https://claude.com/claude-code)